### PR TITLE
Better debugging infos

### DIFF
--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -33,7 +33,7 @@ func main() {
 			fprocessCmd := exec.Command(parts[0], parts[1:]...)
 			//
 
-			// get a reference on all outputs for the fprocess (as byte[])
+			// get a reference on all outputs for the fprocess (as bytes.Buffer)
 			var stdout bytes.Buffer
 			fprocessCmd.Stdout = &stdout
 

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -14,8 +14,8 @@ import (
 func main() {
 	s := &http.Server{
 		Addr:           ":8080",
-		ReadTimeout:    25 * time.Second,
-		WriteTimeout:   25 * time.Second,
+		ReadTimeout:    5 * time.Second,
+		WriteTimeout:   5 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
 

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -27,9 +27,9 @@ func main() {
 			res, _ := ioutil.ReadAll(r.Body)
 			writer.Write(res)
 			writer.Close()
-			out, err := targetCmd.Output()
+			out, err := targetCmd.CombinedOutput()
 			if err != nil {
-				panic(err)
+				panic(err.Error() + "\n" + string(out))
 			}
 
 			os.Stdout.Write(out)

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -13,27 +14,72 @@ import (
 func main() {
 	s := &http.Server{
 		Addr:           ":8080",
-		ReadTimeout:    5 * time.Second,
-		WriteTimeout:   5 * time.Second,
+		ReadTimeout:    25 * time.Second,
+		WriteTimeout:   25 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
+			// get the fprocess to execute and it's args
 			process := os.Getenv("fprocess")
+			//
+
+			// split the fprocess and it's args
 			parts := strings.Split(process, " ")
-			targetCmd := exec.Command(parts[0], parts[1:]...)
-			writer, _ := targetCmd.StdinPipe()
+			//
+
+			// prepare the Command object for the fprocess
+			fprocessCmd := exec.Command(parts[0], parts[1:]...)
+			//
+
+			// get a reference on all outputs for the fprocess (as byte[])
+			var stdout bytes.Buffer
+			fprocessCmd.Stdout = &stdout
+
+			var stderr bytes.Buffer
+			fprocessCmd.Stderr = &stderr
+			//
+
+			// write the http.Request's POST body to the stdin of the fprocess
+			stdin, _ := fprocessCmd.StdinPipe()
 			res, _ := ioutil.ReadAll(r.Body)
-			writer.Write(res)
-			writer.Close()
-			out, err := targetCmd.CombinedOutput()
+			stdin.Write(res)
+			stdin.Close()
+			//
+			
+			// execute the fprocess
+			err := fprocessCmd.Run()
+			//
+
 			if err != nil {
-				panic(err.Error() + "\n" + string(out))
+				// get the fprocess's stderr content
+				errorStack := stderr.String()
+				//
+
+				// print the error's details to the logger
+				log.Println(err.Error())
+				log.Println(errorStack)
+				//
+
+				// send the http response with the error that occured
+				w.WriteHeader(500)
+				response := bytes.NewBufferString(err.Error() + "\n" + errorStack)
+				w.Write(response.Bytes())
+				//
+
+				return
 			}
 
-			os.Stdout.Write(out)
-			w.Write(out)
+			// TODO: consider stdout to container as configurable via env-variable.
+			// write the fprocess's stdout to the fwatchdog stdout
+			os.Stdout.Write(stdout.Bytes())
+			//
+
+			// send the http response with the fprocess's stdout
+			w.WriteHeader(200)
+			w.Write(stdout.Bytes())
+			//
 		}
 	})
 


### PR DESCRIPTION
When the "fprocess" started by the watchdog is failing, the stderr of the "fprocess" is lost... That made debugging very hard cause you got output from the "panic(err)" whitout much infos like this : "2017/01/23 10:55:20 http: panic serving 10.0.1.3:41882: exit status 1".

With this change, you have also the stderr of the "fprocess" printed in console (docker logs [container_id]).