### PR TITLE
Fix buffer dead-lock in Watchdog

### DIFF
--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -20,42 +21,64 @@ func (OsEnv) Getenv(key string) string {
 	return os.Getenv(key)
 }
 
+func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(config.faasProcess, " ")
+
+	targetCmd := exec.Command(parts[0], parts[1:]...)
+	writer, _ := targetCmd.StdinPipe()
+
+	var out []byte
+	var err error
+	var res []byte
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		res, _ = ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+	}()
+
+	go func() {
+		defer wg.Done()
+		writer.Write(res)
+		writer.Close()
+	}()
+
+	go func() {
+		defer wg.Done()
+		out, err = targetCmd.CombinedOutput()
+	}()
+
+	wg.Wait()
+
+	if err != nil {
+		if config.writeDebug == true {
+			log.Println(targetCmd, err)
+		}
+
+		w.WriteHeader(500)
+		response := bytes.NewBufferString(err.Error())
+		w.Write(response.Bytes())
+		return
+	}
+	if config.writeDebug == true {
+		os.Stdout.Write(out)
+	}
+
+	// Match header for strict services
+	if r.Header.Get("Content-Type") == "application/json" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(200)
+	w.Write(out)
+}
+
 func makeRequestHandler(config *WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
-			parts := strings.Split(config.faasProcess, " ")
-
-			targetCmd := exec.Command(parts[0], parts[1:]...)
-			writer, _ := targetCmd.StdinPipe()
-
-			res, _ := ioutil.ReadAll(r.Body)
-			defer r.Body.Close()
-
-			writer.Write(res)
-			writer.Close()
-
-			out, err := targetCmd.CombinedOutput()
-
-			if err != nil {
-				if config.writeDebug == true {
-					log.Println(targetCmd, err)
-				}
-
-				w.WriteHeader(500)
-				response := bytes.NewBufferString(err.Error())
-				w.Write(response.Bytes())
-				return
-			}
-			if config.writeDebug == true {
-				os.Stdout.Write(out)
-			}
-
-			// Match header for strict services
-			if r.Header.Get("Content-Type") == "application/json" {
-				w.Header().Set("Content-Type", "application/json")
-			}
-			w.WriteHeader(200)
-			w.Write(out)
+			pipeRequest(config, w, r)
 		} else {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -32,13 +32,10 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 	var res []byte
 
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(2)
 
-	go func() {
-		defer wg.Done()
-		res, _ = ioutil.ReadAll(r.Body)
-		defer r.Body.Close()
-	}()
+	res, _ = ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
 
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix buffer dead-lock in Watchdog.

## Motivation and Context

Payloads of > 64KB choked due to buffer blocking waiting for another Goroutine to read at the other end. 

Fixes issue #31 

## How Has This Been Tested?

Tested with 1.9MB JPG / PNG through watchdog and gateway.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
