### PR TITLE
DNS-rr flag and Watchdog healthcheck

### DIFF
--- a/sample-functions/AlpineFunction/Dockerfile
+++ b/sample-functions/AlpineFunction/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:latest
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+# COPY ./fwatchdog /usr/bin/
 RUN chmod +x /usr/bin/fwatchdog
 
 # Populate example here
 # ENV fprocess="wc -l"
+
+HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]

--- a/sample-functions/AlpineFunction/README.md
+++ b/sample-functions/AlpineFunction/README.md
@@ -1,0 +1,5 @@
+## AlpineFunction
+
+This is a base image for Alpine Linux which already has the watchdog added and configured with a healthcheck.
+
+This image is published on the Docker hub as `functions/alpine`.

--- a/sample-functions/ApiKeyProtected/Dockerfile
+++ b/sample-functions/ApiKeyProtected/Dockerfile
@@ -6,8 +6,8 @@ EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-# ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
-COPY fwatchdog  /usr/bin/
+ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+# COPY fwatchdog  /usr/bin/
 RUN chmod +x /usr/bin/fwatchdog
 
 COPY app    .

--- a/sample-functions/WebhookStash/Dockerfile
+++ b/sample-functions/WebhookStash/Dockerfile
@@ -6,7 +6,8 @@ RUN go get -d -v
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+
 RUN chmod +x /usr/bin/fwatchdog
 # COPY fwatchdog  /usr/bin/
 

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -25,13 +25,35 @@ ENV fprocess="/bin/cat"
 CMD ["fwatchdog"]
 ```
 
+**Implementing the a healthcheck**
+
+Docker swarm will keep your function out of the DNS-RR / IPVS pool if the task (container) is not healthy.
+
+Here is an example of the `echo` function implementing a healthcheck with a 5-second checking interval.
+
+```
+FROM functions/alpine
+
+ENV fprocess="cat /etc/hostname"
+
+HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
+```
+
+The watchdog process creates a .lock file in `/tmp/` on starting its internal Golang HTTP server. `[ -e file_name ]` is shell to check if a file exists.
+
+Swarm tutorial on Healthchecks:
+
+ * [Test-drive Docker Healthcheck in 10 minutes](http://blog.alexellis.io/test-drive-healthcheck/)
+
+
 **Environmental overrides:**
 
 A number of environmental overrides can be added for additional flexibility and options:
 
 | Option                 | Usage             |
 |------------------------|--------------|
-| `fprocess`     | The process to invoke for each function call. This must be a UNIX binary and accept input via STDIN and output via STDOUT.  |
+| `fprocess`             | The process to invoke for each function call. This must be a UNIX binary and accept input via STDIN and output via STDOUT.  |
 | `marshal_requests`     | Instead of re-directing the raw HTTP body into your fprocess, it will first be marshalled into JSON. Use this if you need to work with HTTP headers |
-| `write_timeout`     | HTTP timeout for writing a response body from your function  |
-| `read_timeout`     | HTTP timeout for reading the payload from the client caller  |
+| `write_timeout`        | HTTP timeout for writing a response body from your function  |
+| `read_timeout`         | HTTP timeout for reading the payload from the client caller  |
+| `suppress_lock`        | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |

--- a/watchdog/build.sh
+++ b/watchdog/build.sh
@@ -3,7 +3,7 @@
 # Below makes use of "builder pattern" so that binary is extracted separate
 # from the golang runtime/SDK
 
-docker build --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy \
+docker build --no-cache --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy \
     -t functions/watchdog:build .
 docker create --name buildoutput functions/watchdog:build echo
 docker cp buildoutput:/go/src/github.com/alexellis/faas/watchdog/watchdog ./fwatchdog

--- a/watchdog/config_test.go
+++ b/watchdog/config_test.go
@@ -29,19 +29,46 @@ func TestRead_WriteDebug_DefaultIsTrueConfig(t *testing.T) {
 	config := readConfig.Read(defaults)
 
 	if config.writeDebug != true {
-		t.Logf("writeDebug should have been true")
+		t.Logf("writeDebug should have been true (unspecified)")
 		t.Fail()
 	}
 }
-func TestRead_WriteDebug_FalseConfig(t *testing.T) {
+
+func TestRead_WriteDebug_FalseOverrideConfig(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := ReadConfig{}
-	defaults.Setenv("writeDebug", "true")
+	defaults.Setenv("write_debug", "false")
+
+	config := readConfig.Read(defaults)
+
+	if config.writeDebug != false {
+		t.Logf("writeDebug should have been false (specified)")
+		t.Fail()
+	}
+}
+
+func TestRead_WriteDebug_TrueConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+	defaults.Setenv("write_debug", "true")
 
 	config := readConfig.Read(defaults)
 
 	if config.writeDebug != true {
-		t.Logf("writeDebug should have been true")
+		t.Logf("writeDebug should have been true (specified)")
+		t.Fail()
+	}
+}
+
+func TestRead_SuppressLockConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+	defaults.Setenv("suppress_lock", "true")
+
+	config := readConfig.Read(defaults)
+
+	if config.suppressLock != true {
+		t.Logf("suppress_lock envVariable incorrect, got: %s.\n", config.faasProcess)
 		t.Fail()
 	}
 }

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -22,9 +22,9 @@ func buildFunctionInput(config *WatchdogConfig, r *http.Request) ([]byte, error)
 
 	defer r.Body.Close()
 	requestBytes, _ = ioutil.ReadAll(r.Body)
-	if config.marshallRequest {
-		marshalRes, marshallErr := types.MarshalRequest(requestBytes, &r.Header)
-		err = marshallErr
+	if config.marshalRequest {
+		marshalRes, marshalErr := types.MarshalRequest(requestBytes, &r.Header)
+		err = marshalErr
 		res = marshalRes
 	} else {
 		res = requestBytes
@@ -134,6 +134,13 @@ func main() {
 	}
 
 	http.HandleFunc("/", makeRequestHandler(&config))
+
+	if config.suppressLock == false {
+		writeErr := ioutil.WriteFile("/tmp/.lock", []byte{}, 0660)
+		if writeErr != nil {
+			log.Panicf("Cannot write /tmp/.lock for healthcheck: %s \n", writeErr.Error())
+		}
+	}
 
 	log.Fatal(s.ListenAndServe())
 }

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -136,9 +136,11 @@ func main() {
 	http.HandleFunc("/", makeRequestHandler(&config))
 
 	if config.suppressLock == false {
-		writeErr := ioutil.WriteFile("/tmp/.lock", []byte{}, 0660)
+		path := "/tmp/.lock"
+		log.Printf("Writing lock-file to: %s\n", path)
+		writeErr := ioutil.WriteFile(path, []byte{}, 0660)
 		if writeErr != nil {
-			log.Panicf("Cannot write /tmp/.lock for healthcheck: %s \n", writeErr.Error())
+			log.Panicf("Cannot write %s. Error: %s\n", path, writeErr.Error())
 		}
 	}
 

--- a/watchdog/readconfig.go
+++ b/watchdog/readconfig.go
@@ -57,9 +57,9 @@ func (ReadConfig) Read(hasEnv HasEnv) WatchdogConfig {
 
 	cfg.writeDebug = parseBoolValue(hasEnv.Getenv("write_debug"))
 
-	cfg.marshallRequest = parseBoolValue(hasEnv.Getenv("marshall_request"))
+	cfg.marshalRequest = parseBoolValue(hasEnv.Getenv("marshal_request"))
 	cfg.debugHeaders = parseBoolValue(hasEnv.Getenv("debug_headers"))
-
+	cfg.suppressLock = parseBoolValue(hasEnv.Getenv("suppress_lock"))
 	return cfg
 }
 
@@ -74,8 +74,11 @@ type WatchdogConfig struct {
 	// writeDebug write console stdout statements to the container
 	writeDebug bool
 
-	marshallRequest bool
+	marshalRequest bool
 
 	// prints out all incoming and out-going HTTP headers
 	debugHeaders bool
+
+	// Don't write a lock file to /tmp/
+	suppressLock bool
 }

--- a/watchdog/readconfig.go
+++ b/watchdog/readconfig.go
@@ -18,7 +18,7 @@ func parseBoolValue(val string) bool {
 	if val == "true" {
 		return true
 	}
-	return true
+	return false
 }
 
 func parseIntValue(val string) int {
@@ -55,11 +55,15 @@ func (ReadConfig) Read(hasEnv HasEnv) WatchdogConfig {
 	cfg.readTimeout = time.Duration(readTimeout) * time.Second
 	cfg.writeTimeout = time.Duration(writeTimeout) * time.Second
 
-	cfg.writeDebug = parseBoolValue(hasEnv.Getenv("write_debug"))
+	if len(hasEnv.Getenv("write_debug")) > 0 {
+		cfg.writeDebug = parseBoolValue(hasEnv.Getenv("write_debug"))
+	}
 
 	cfg.marshalRequest = parseBoolValue(hasEnv.Getenv("marshal_request"))
 	cfg.debugHeaders = parseBoolValue(hasEnv.Getenv("debug_headers"))
+
 	cfg.suppressLock = parseBoolValue(hasEnv.Getenv("suppress_lock"))
+
 	return cfg
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
DNS-rr flag and Watchdog healthcheck

## Motivation and Context

Gateway - enable DNS-RR as lookup option instead of VIP for high-load performance testing.
Watchdog - enable lock file for use with healthcheck in binary

## How Has This Been Tested?

DNS rr flag tested with `docker service logs func_gateway` after scaling function.

Healthcheck tested with sample function. Need to bake-in a timeout into each function or base image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

Could do with automated DIND tests for this scenario. 
