### PR TITLE
Provide override for replica scaling to cap out at custom value.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
         image: functions/alpine:latest
         labels:
             function: "true"
+            com.faas.max_replicas: "10"
         depends_on:
             - gateway
         networks:

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -45,7 +45,6 @@ Swarm tutorial on Healthchecks:
 
  * [Test-drive Docker Healthcheck in 10 minutes](http://blog.alexellis.io/test-drive-healthcheck/)
 
-
 **Environmental overrides:**
 
 A number of environmental overrides can be added for additional flexibility and options:
@@ -57,3 +56,32 @@ A number of environmental overrides can be added for additional flexibility and 
 | `write_timeout`        | HTTP timeout for writing a response body from your function  |
 | `read_timeout`         | HTTP timeout for reading the payload from the client caller  |
 | `suppress_lock`        | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
+
+## Advanced / tuning
+
+**Content-Type of request/response**
+
+By default the watchdog will match the response of your function to the "Content-Type" of the client.
+
+* If your client sends a JSON post with a Content-Type of `application/json` this will be matched automatically in the response.
+* If your client sends a JSON post with a Content-Type of `text/plain` this will be matched automatically in the response too
+
+See open issues for custom override of response ContentType.
+
+
+**Tuning auto-scaling**
+
+Auto-scaling starts at 1 replica and steps up in blocks of 5:
+
+* 1->5
+* 5->10
+* 10->15
+* 15->20
+
+You can override the upper limit of auto-scaling by setting the following label on your container:
+
+```
+com.faas.max_replicas: "10"
+```
+
+If you want to disable scaling, set the `com.faas.max_replicas` value to `"1"`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Provide override for replica scaling to cap out at custom value.

## Motivation and Context

* A function can have a max override of 1 - i.e. it should not scale.
* A function should be able to scale beyond the hard-coded limit of 20 replicas.

A new label for container spec allows this:

```
com.faas.max_replicas: "10"
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing functions unaffected. Tested with sample compose stack. After reaching max_replicas limit, the scaling will stop increasing replicas.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
