### PR TITLE
Allow override of contentType response from watchdog.

### DIFF
--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -53,6 +53,7 @@ A number of environmental overrides can be added for additional flexibility and 
 |------------------------|--------------|
 | `fprocess`             | The process to invoke for each function call. This must be a UNIX binary and accept input via STDIN and output via STDOUT.  |
 | `marshal_requests`     | Instead of re-directing the raw HTTP body into your fprocess, it will first be marshalled into JSON. Use this if you need to work with HTTP headers |
+| `content_type`         | Force a specific Content-Type response for all responses.    |
 | `write_timeout`        | HTTP timeout for writing a response body from your function  |
 | `read_timeout`         | HTTP timeout for reading the payload from the client caller  |
 | `suppress_lock`        | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
@@ -66,8 +67,7 @@ By default the watchdog will match the response of your function to the "Content
 * If your client sends a JSON post with a Content-Type of `application/json` this will be matched automatically in the response.
 * If your client sends a JSON post with a Content-Type of `text/plain` this will be matched automatically in the response too
 
-See open issues for custom override of response ContentType.
-
+To override the Content-Type of all your responses set the `content_type` environmental variable.
 
 **Tuning auto-scaling**
 

--- a/watchdog/config_test.go
+++ b/watchdog/config_test.go
@@ -73,6 +73,19 @@ func TestRead_SuppressLockConfig(t *testing.T) {
 	}
 }
 
+func TestRead_ContentTypeConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+	defaults.Setenv("content_type", "application/json")
+
+	config := readConfig.Read(defaults)
+
+	if config.contentType != "application/json" {
+		t.Logf("content_type envVariable incorrect, got: %s.\n", config.contentType)
+		t.Fail()
+	}
+}
+
 func TestRead_FprocessConfig(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := ReadConfig{}

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -89,9 +89,15 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 		os.Stdout.Write(out)
 	}
 
-	clientContentType := r.Header.Get("Content-Type")
-	if len(clientContentType) > 0 {
-		w.Header().Set("Content-Type", "application/json")
+	if len(config.contentType) > 0 {
+		w.Header().Set("Content-Type", config.contentType)
+	} else {
+
+		// Match content-type of caller if no override specified.
+		clientContentType := r.Header.Get("Content-Type")
+		if len(clientContentType) > 0 {
+			w.Header().Set("Content-Type", clientContentType)
+		}
 	}
 
 	w.WriteHeader(200)

--- a/watchdog/readconfig.go
+++ b/watchdog/readconfig.go
@@ -64,6 +64,8 @@ func (ReadConfig) Read(hasEnv HasEnv) WatchdogConfig {
 
 	cfg.suppressLock = parseBoolValue(hasEnv.Getenv("suppress_lock"))
 
+	cfg.contentType = hasEnv.Getenv("content_type")
+
 	return cfg
 }
 
@@ -85,4 +87,7 @@ type WatchdogConfig struct {
 
 	// Don't write a lock file to /tmp/
 	suppressLock bool
+
+	// contentType forces a specific pre-defined value for all responses
+	contentType string
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow override of contentType response from watchdog for when it does not match caller contentType. I.e. JSON request and binary output.

## Motivation and Context

Fixes #45 

## How Has This Been Tested?

```
$ content_type=text/plain marshal_request=true fprocess=/bin/cat ./watchdog 
```

Shows response contentType set to text/plain.

```
$ marshal_request=true fprocess=/bin/cat ./watchdog 
```

Shows existing behavior of response contentType being matched.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
