### PR TITLE
Switch from quay.io

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
                 constraints: [node.role == manager]
 
     alertmanager:
-        image: quay.io/prometheus/alertmanager
+        image: prom/alertmanager:v0.5.1 # quai.io is banned in some countries.
         environment:
             no_proxy: "gateway"
         volumes:


### PR DESCRIPTION
quay.io and Docker hub images are identical. Switching over to the Hub since quay seems to have been blocked in China for use on Alibaba cloud.