### PR TITLE
add Azure deployment template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ fwatchdog
 fwatchdog-armhf
 **/node_modules/
 **/*.DS_Store
+.vscode

--- a/contrib/azure/Makefile
+++ b/contrib/azure/Makefile
@@ -1,0 +1,125 @@
+# Set environment variables (if they're not defined yet)
+export RESOURCE_GROUP?=faas-cluster
+# check valid locations with "make locations"
+export LOCATION?=northeurope
+export MASTER_COUNT?=1
+export AGENT_COUNT?=2
+export MASTER_FQDN=$(RESOURCE_GROUP)-master0.$(LOCATION).cloudapp.azure.com
+# The load balancer isn't used yet - maybe when the Admin UI can be split from the gateway
+export LOADBALANCER_FQDN=$(RESOURCE_GROUP)-agents-lb.$(LOCATION).cloudapp.azure.com
+export VMSS_NAME=agents
+
+MASTER_REPO_URL=https://raw.githubusercontent.com/alexellis/faas/master
+
+# Generated key files (if you don't want to use your existing ones)
+SSH_KEY_FILES := faas.pem faas.pub
+ADMIN_USERNAME := faas
+TEMPLATE_FILE := faas-cluster-template.json
+PARAMETERS_FILE := faas-cluster-parameters.json
+
+# Helper targets for folk not used to Azure
+
+## Dump resource groups
+resources:
+	az group list --output table
+
+
+## Dump list of location IDs
+locations:
+	az account list-locations --output table
+
+
+## Generate SSH keys for the cluster
+keys:
+	ssh-keygen -b 2048 -t rsa -f faas -q -N ""
+	mv faas faas.pem
+
+
+## Generate Azure Resource Template parameter files
+params:
+	python genparams.py
+
+
+## Destroy the entire resource group and all cluster resources
+destroy-cluster:
+	az group delete --name $(RESOURCE_GROUP)
+
+
+## Create a resource group and deploy the cluster resources inside it
+deploy-cluster:
+	-az group create --name $(RESOURCE_GROUP) --location $(LOCATION) --output table 
+	az group deployment create --template-file $(TEMPLATE_FILE) --parameters @$(PARAMETERS_FILE) --resource-group $(RESOURCE_GROUP) --name cli-deployment-$(LOCATION) --output table
+
+
+## Deploy the FaaS stack
+## TODO: move the Prometheus setup to cloud-init
+deploy-stack:
+	cat deploy-stack.sh | ssh -A -i faas.pem $(ADMIN_USERNAME)@$(MASTER_FQDN) \
+	-o "UserKnownHostsFile /dev/null" \
+	-o "StrictHostKeyChecking no"
+	
+
+## Deploy the Swarm monitor
+deploy-monitor:
+	ssh -i faas.pem $(ADMIN_USERNAME)@$(MASTER_FQDN) \
+	-o "UserKnownHostsFile /dev/null" \
+	-o "StrictHostKeyChecking no" \
+	docker run -it -d -p 8080:8080 -e HOST=$(MASTER_FQDN) -v /var/run/docker.sock:/var/run/docker.sock manomarks/visualizer 
+
+
+## Kill the swarm monitor
+kill-monitor:
+	ssh -i faas.pem $(ADMIN_USERNAME)@$(MASTER_FQDN) \
+	-o "UserKnownHostsFile /dev/null" \
+	-o "StrictHostKeyChecking no" \
+	"docker ps | grep manomarks/visualizer | cut -d\  -f 1 | xargs docker kill"
+
+
+## Cleanup parameters
+clean:
+	rm -f $(SSH_KEY_FILES) $(PARAMETERS_FILE)
+
+
+## SSH to master node and make admin UI interface available locally
+# Note that we're explicitly skipping host key checking to avoid polluting known_hosts
+# when instancing multiple clusters
+proxy:
+	ssh -A -i faas.pem $(ADMIN_USERNAME)@$(MASTER_FQDN) \
+	-o "UserKnownHostsFile /dev/null" \
+	-o "StrictHostKeyChecking no" \
+	-L 8080:localhost:8080 \
+	-L 9090:localhost:9090 \
+	-L 9093:localhost:9093
+
+
+## Show swarm helper log
+tail-helper:
+	ssh -i faas.pem $(ADMIN_USERNAME)@$(MASTER_FQDN) \
+	-o "UserKnownHostsFile /dev/null" \
+	-o "StrictHostKeyChecking no" \
+	sudo journalctl -f -u swarm-helper
+
+
+## List agent instances
+list-agents:
+	az vmss list-instances --resource-group $(RESOURCE_GROUP) --name $(VMSS_NAME) --output table 
+
+
+## Scale agent instances
+scale-agents-%:
+	az vmss scale --resource-group $(RESOURCE_GROUP) --name $(VMSS_NAME) --new-capacity $* --output table 
+
+
+## Stop all agent instances
+stop-agents:
+	az vmss stop --resource-group $(RESOURCE_GROUP) --name $(VMSS_NAME) --output table 
+
+
+## Start all agent instances
+start-agents:
+	az vmss start --resource-group $(RESOURCE_GROUP) --name $(VMSS_NAME) --output table 
+
+
+# List public IP endpoints
+list-endpoints:
+	az network public-ip list --query '[].{dnsSettings:dnsSettings.fqdn}' --resource-group $(RESOURCE_GROUP) --output table

--- a/contrib/azure/Makefile
+++ b/contrib/azure/Makefile
@@ -9,13 +9,11 @@ export MASTER_FQDN=$(RESOURCE_GROUP)-master0.$(LOCATION).cloudapp.azure.com
 export LOADBALANCER_FQDN=$(RESOURCE_GROUP)-agents-lb.$(LOCATION).cloudapp.azure.com
 export VMSS_NAME=agents
 
-MASTER_REPO_URL=https://raw.githubusercontent.com/alexellis/faas/master
-
 # Generated key files (if you don't want to use your existing ones)
-SSH_KEY_FILES := faas.pem faas.pub
-ADMIN_USERNAME := faas
-TEMPLATE_FILE := faas-cluster-template.json
-PARAMETERS_FILE := faas-cluster-parameters.json
+export ADMIN_USERNAME?=faas
+SSH_KEY_FILES:=$(ADMIN_USERNAME).pem $(ADMIN_USERNAME).pub
+TEMPLATE_FILE:=faas-luster-template.json
+PARAMETERS_FILE:=faas-cluster-parameters.json
 
 # Helper targets for folk not used to Azure
 
@@ -31,13 +29,13 @@ locations:
 
 ## Generate SSH keys for the cluster
 keys:
-	ssh-keygen -b 2048 -t rsa -f faas -q -N ""
-	mv faas faas.pem
+	ssh-keygen -b 2048 -t rsa -f $(ADMIN_USERNAME) -q -N ""
+	mv $(ADMIN_USERNAME) $(ADMIN_USERNAME).pem
 
 
 ## Generate Azure Resource Template parameter files
 params:
-	python genparams.py
+	python genparams.py $(ADMIN_USERNAME) > $(PARAMETERS_FILE)
 
 
 ## Destroy the entire resource group and all cluster resources

--- a/contrib/azure/README.md
+++ b/contrib/azure/README.md
@@ -1,0 +1,28 @@
+# Azure FaaS Cluster Template
+
+This an experimental Azure template for deploying FaaS on live infra, based on a [barebones Swarm template][t] that deploys a master node and a dynamically scalable set of agent nodes. As configured, Azure will deploy more agents and expand infrastructure capacity as required by CPU load.
+
+## Requirements
+
+You need an Azure subscription, the `az` CLI, Python and the `make` command.
+
+## TL;DR
+
+    az login
+    make keys
+    make params
+    make deploy-cluster
+    make deploy-stack
+    make proxy
+
+    open http://localhost:8080
+
+## How it Works
+
+The cluster template defines a fixed set of master VMs (defaulting to 1) and an Azure VM scaleset (with 2 agent instances) that auto-scales based on CPU load, as well as a public load balancer mapped to the agent instances.
+
+Both masters and agents are provisioned using `cloud-init`, which installs Docker CE and expands the Swarm cluster on the fly thanks to a set of simple helper scripts that make Swarm aware of when the infrastructure is scaling.
+
+For security reasons, the admin and Prometheus UIs are only accessible via SSH tunnelling by default. Once the admin UI can be deployed separately, exposing functions via the public load balancer will be trivial.
+
+[t]: https://github.com/rcarmo/azure-docker-swarm-cluster

--- a/contrib/azure/cloud-config-agent.yml
+++ b/contrib/azure/cloud-config-agent.yml
@@ -1,0 +1,74 @@
+#cloud-config
+
+write_files:
+  - path: /root/join-swarm.sh
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      # make sure there's no disk state that points to an existing swarm
+      docker swarm leave
+      # get the swarm worker token
+      TOKEN=$(wget -nv -q -O - --retry-connrefused 10 --waitretry 5 http://master0:1337/join/worker)
+      docker swarm join --token $TOKEN master0:2377
+  - path: /root/leave-swarm.sh
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      HOSTNAME=$(hostname)
+      # signal the master to drain services from our node
+      wget -nv -q -O - --retry-connrefused 10 --waitretry 5 http://master0:1337/drain/$HOSTNAME
+      docker swarm leave
+  - path: /etc/systemd/system/swarm-join.service
+    permissions: 0444
+    content: |
+      [Unit]
+      Description=Join Swarm
+      DefaultDependencies=no
+      After=multi-user.target
+      [Service]
+      Type=oneshot
+      ExecStart=/root/join-swarm.sh
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/swarm-leave.service
+    permissions: 0444
+    content: |
+      [Unit]
+      Description=Leave Swarm
+      DefaultDependencies=no
+      Before=shutdown.target reboot.target halt.target
+      [Service]
+      Type=oneshot
+      ExecStart=/root/leave-swarm.sh
+      [Install]
+      WantedBy=halt.target reboot.target shutdown.target
+
+apt:
+  sources:
+    docker_ce.list:
+      source: "deb https://download.docker.com/linux/ubuntu xenial stable"
+      keyserver: p80.pool.sks-keyservers.net
+      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+
+# Skip upgrading the agents for quicker spin-up
+#apt_update: true
+#apt_upgrade: true
+
+packages:
+  - ntp
+  - docker-ce
+  #- tmux
+  #- htop
+  #- vim
+  - fail2ban
+  #- curl
+
+runcmd:
+  - usermod -G docker faas
+  - systemctl enable docker
+  - systemctl enable swarm-join
+  - systemctl enable swarm-leave
+  - systemctl start docker
+  - systemctl start swarm-leave
+  - systemctl start swarm-join
+  #- reboot

--- a/contrib/azure/cloud-config-master.yml
+++ b/contrib/azure/cloud-config-master.yml
@@ -1,0 +1,84 @@
+#cloud-config
+
+write_files:
+  - path: /root/swarm-helper.py
+    permissions: 0755
+    content: |
+      #!/usr/bin/env python
+      from bottle import get, run, abort
+      from subprocess import check_output
+      from socket import gethostname
+      from signal import signal, setitimer, ITIMER_REAL, SIGALRM
+
+      def cleanup(signum, frame):
+          try:
+              nodes = check_output('docker node ls', shell=True).strip()
+              down = map(lambda x: x.split()[1], filter(lambda x: 'Down' in x, nodes.split("\n")))
+              for node in down:
+                  check_output('docker node rm ' + node, shell=True)
+          except:
+              pass
+
+      @get("/join/worker")
+      def token():
+          return check_output('docker swarm join-token -q worker', shell=True).strip()
+
+      @get("/join/master")
+      def token():
+          return check_output('docker swarm join-token -q master', shell=True).strip()
+      
+      @get("/drain/<hostname>")
+      def drain(hostname):
+          try:
+              return check_output('docker node update --availability drain ' + hostname, shell=True).strip()
+          except:
+              abort(404, "node not found")
+        
+      if gethostname() == 'master0':
+          try:
+              check_output('docker swarm init', shell=True)
+          except:
+              pass
+          signal(SIGALRM, cleanup)
+          setitimer(ITIMER_REAL, 10, 10)
+          run(port=1337,host='0.0.0.0')
+  - path: /etc/systemd/system/swarm-helper.service
+    permissions: 0444
+    content: |
+      [Unit]
+      Description=Swarm Helper
+      DefaultDependencies=no
+      After=multi-user.target
+      [Service]
+      Type=oneshot
+      ExecStart=/root/swarm-helper.py
+      [Install]
+      WantedBy=multi-user.target
+
+apt:
+  sources:
+    docker_ce.list:
+      source: "deb https://download.docker.com/linux/ubuntu xenial stable"
+      keyserver: p80.pool.sks-keyservers.net
+      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+
+#apt_update: true
+#apt_upgrade: true
+
+packages:
+  - ntp
+  - docker-ce
+  - tmux
+  - htop
+  - vim
+  - fail2ban
+  - curl
+  - python-bottle
+
+runcmd:
+  - usermod -G docker faas
+  - systemctl enable docker
+  - systemctl start docker
+  - systemctl enable swarm-helper
+  - systemctl start swarm-helper
+  #- reboot

--- a/contrib/azure/deploy-stack.sh
+++ b/contrib/azure/deploy-stack.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+MASTER_REPO_URL=https://raw.githubusercontent.com/alexellis/faas/master
+curl -O $MASTER_REPO_URL/docker-compose.yml
+mkdir prometheus
+cd prometheus
+curl -O $MASTER_REPO_URL/prometheus/alert.rules
+curl -O $MASTER_REPO_URL/prometheus/alertmanater.yml
+curl -O $MASTER_REPO_URL/prometheus/prometheus.yml
+cd
+docker stack deploy func --compose-file docker-compose.yml

--- a/contrib/azure/faas-cluster-template.json
+++ b/contrib/azure/faas-cluster-template.json
@@ -1,0 +1,575 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "masterPrefix": {
+      "type": "string",
+      "defaultValue": "master",
+      "metadata": {
+        "description": "Master node(s) name prefix"
+      }
+    },
+    "masterCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Number of master VM instances (1,3 or 5)"
+      },
+      "allowedValues": [
+        1,
+        3,
+        5
+      ]
+    },
+    "masterSize": {
+      "type": "string",
+      "defaultValue": "Standard_DS1_v2",
+      "metadata": {
+        "description": "Master instance size"
+      },
+      "allowedValues": [
+        "Standard_DS1_v2",
+        "Standard_DS2_v2",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_F1",
+        "Standard_F2"
+      ]
+    },
+    "agentPrefix": {
+      "type": "string",
+      "defaultValue": "agents"
+    },
+    "agentCount": {
+      "type": "int",
+      "metadata": {
+        "description": "Number of agent VM instances (100 or less)."
+      },
+      "defaultValue": 2,
+      "minValue": 1,
+      "maxValue": 100
+    },
+    "agentSize": {
+      "type": "string",
+      "defaultValue": "Standard_DS1_v2",
+      "metadata": {
+        "description": "Agent instance size"
+      },
+      "allowedValues": [
+        "Standard_DS1_v2",
+        "Standard_DS2_v2",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_F1",
+        "Standard_F2"
+      ]
+    },
+    "adminUsername": {
+      "type": "string",
+      "defaultValue": "cluster",
+      "metadata": {
+        "description": "Admin username on all VMs."
+      }
+    },
+    "adminPublicKey": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "ssh public key for connecting to VMs."
+      }
+    },
+    "masterCustomData": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Base64 encoded, multi-line string to pass to Ubuntu cloud-init"
+      }
+    },
+    "agentCustomData": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Base64 encoded, multi-line string to pass to Ubuntu cloud-init"
+      }
+    },
+    "asFDCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "metadata": {
+        "description": "Master Availability Set Fault Domains"
+      }
+    },
+    "asUDCount": {
+      "type": "int",
+      "defaultValue": 5,
+      "metadata": {
+        "description": "Master Availability Set Update Domains"
+      }
+    },
+    "saType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Premium_LRS"
+      ]
+    },
+    "diskSizeGB": {
+      "type": "int",
+      "defaultValue": 20,
+      "allowedValues": [
+        20,
+        50,
+        100
+      ]
+    }
+  },
+  "variables": {
+    "diagsName": "[toLower(substring(concat(parameters('masterPrefix'), 'diag',  uniqueString(resourceGroup().id)), 0, 16))]",
+    "natStartPort": 50000,
+    "natEndPort": 50099,
+    "natBackendPort": 22
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('diagsName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "comments": "Virtual Network",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "cluster",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/8"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "masters",
+            "properties": {
+              "addressPrefix": "10.1.0.0/16"
+            }
+          },
+          {
+            "name": "agents",
+            "properties": {
+              "addressPrefix": "10.2.0.0/16"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comments": "Master Node(s)",
+      "type": "Microsoft.Compute/virtualMachines",
+      "copy": {
+        "name": "masters",
+        "count": "[parameters('masterCount')]"
+      },
+      "name": "[concat(parameters('masterPrefix'),copyIndex())]",
+      "apiVersion": "2016-04-30-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "osProfile": {
+          "computerName": "[concat(parameters('masterPrefix'),copyIndex())]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "customData": "[parameters('masterCustomData')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                  "keyData": "[parameters('adminPublicKey')]"
+                }
+              ]
+            }
+          }
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('masterSize')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "Canonical",
+            "offer": "UbuntuServer",
+            "sku": "16.04.0-LTS",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('masterPrefix'),copyIndex())]",
+            "managedDisk": {
+              "storageAccountType": "[parameters('saType')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "diskSizeGB": "[parameters('diskSizeGB')]"
+          },
+          "dataDisks": []
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('masterPrefix'),copyIndex()))]"
+            }
+          ]
+        },
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'masters')]"
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": true,
+            "storageUri": "[concat('https', '://', variables('diagsName'), '.blob.core.windows.net')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('masterPrefix'), copyIndex())]",
+        "[concat('Microsoft.Compute/availabilitySets/', 'masters')]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('diagsName'))]"
+      ]
+    },
+    {
+      "comments": "Agent ScaleSet",
+      "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "name": "[parameters('agentPrefix')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-04-30-preview",
+      "dependsOn": [
+        "[concat('Microsoft.Network/loadBalancers/', parameters('agentPrefix'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('diagsName'))]"
+      ],
+      "sku": {
+        "name": "[parameters('agentSize')]",
+        "tier": "Standard",
+        "capacity": "[parameters('agentCount')]"
+      },
+      "properties": {
+        "overprovision": "false",
+        "upgradePolicy": {
+          "mode": "Manual"
+        },
+        "virtualMachineProfile": {
+          "osProfile": {
+            "computerNamePrefix": "[parameters('agentPrefix')]",
+            "adminUsername": "[parameters('adminUsername')]",
+            "customData": "[parameters('agentCustomData')]",
+            "linuxConfiguration": {
+              "disablePasswordAuthentication": true,
+              "ssh": {
+                "publicKeys": [
+                  {
+                    "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                    "keyData": "[parameters('adminPublicKey')]"
+                  }
+                ]
+              }
+            }
+          },
+          "storageProfile": {
+            "osDisk": {
+              "managedDisk": {
+                "storageAccountType": "[parameters('saType')]"
+              },
+              "caching": "ReadWrite",
+              "createOption": "FromImage",
+              "diskSizeGB": "[parameters('diskSizeGB')]"
+            },
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04.0-LTS",
+              "version": "latest"
+            }
+          },
+          "diagnosticsProfile": {
+            "bootDiagnostics": {
+              "enabled": true,
+              "storageUri": "[concat('https', '://', variables('diagsName'), '.blob.core.windows.net')]"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "[parameters('agentPrefix')]",
+                "properties": {
+                  "primary": true,
+                  "ipConfigurations": [
+                    {
+                      "name": "[concat(parameters('agentPrefix'),'IpConfig')]",
+                      "properties": {
+                        "subnet": {
+                          "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', 'cluster', '/subnets/', 'agents')]"
+                        },
+                        "loadBalancerBackendAddressPools": [
+                          {
+                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', parameters('agentPrefix'), '/backendAddressPools/', 'agentPool')]"
+                          }
+                        ],
+                        "loadBalancerInboundNatPools": [
+                          {
+                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', parameters('agentPrefix'), '/inboundNatPools/', 'sshPool')]"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "comments": "Autoscale Settings",
+      "type": "microsoft.insights/autoscalesettings",
+      "name": "[parameters('agentPrefix')]",
+      "apiVersion": "2014-04-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "profiles": [
+          {
+            "name": "DefaultProfile",
+            "capacity": {
+              "minimum": "1",
+              "maximum": "10",
+              "default": "1"
+            },
+            "rules": [
+              {
+                "metricTrigger": {
+                  "metricName": "Percentage CPU",
+                  "metricNamespace": "",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('agentPrefix'))]",
+                  "timeGrain": "PT1M",
+                  "statistic": "Average",
+                  "timeWindow": "PT5M",
+                  "timeAggregation": "Average",
+                  "operator": "GreaterThan",
+                  "threshold": 75
+                },
+                "scaleAction": {
+                  "direction": "Increase",
+                  "type": "ChangeCount",
+                  "value": "1",
+                  "cooldown": "PT1M"
+                }
+              },
+              {
+                "metricTrigger": {
+                  "metricName": "Percentage CPU",
+                  "metricNamespace": "",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('agentPrefix'))]",
+                  "timeGrain": "PT1M",
+                  "statistic": "Average",
+                  "timeWindow": "PT5M",
+                  "timeAggregation": "Average",
+                  "operator": "LessThan",
+                  "threshold": 25
+                },
+                "scaleAction": {
+                  "direction": "Decrease",
+                  "type": "ChangeCount",
+                  "value": "1",
+                  "cooldown": "PT1M"
+                }
+              }
+            ]
+          }
+        ],
+        "enabled": true,
+        "name": "[parameters('agentPrefix')]",
+        "targetResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('agentPrefix'))]"
+      },
+      "resources": [],
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('agentPrefix'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "masters",
+      "apiVersion": "2016-04-30-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "managed": "true",
+        "platformFaultDomainCount": "[parameters('asFDCount')]",
+        "platformUpdateDomainCount": "[parameters('asUDCount')]"
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "copy": {
+        "name": "clusterMasterNetworkInterfaces",
+        "count": "[parameters('masterCount')]"
+      },
+      "name": "[concat(parameters('masterPrefix'),copyIndex())]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "primary": true,
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "subnet": {
+                "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', 'cluster'), '/subnets/', 'masters')]"
+              },
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat('10.1.0.',add(10,copyIndex()))]",
+              "publicIpAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIpAddresses', concat(parameters('masterPrefix'), copyIndex()))]"
+              }
+            }
+          }
+        ],
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(parameters('masterPrefix'), copyIndex()))]"
+        }
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', 'cluster')]",
+        "[concat('Microsoft.Network/publicIpAddresses/', parameters('masterPrefix'), copyIndex())]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', parameters('masterPrefix'), copyIndex())]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(parameters('masterPrefix'), copyIndex())]",
+      "copy": {
+        "name": "clusterMasterPublicIPAddresses",
+        "count": "[parameters('masterCount')]"
+      },
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(resourceGroup().name, '-', parameters('masterPrefix'), copyIndex())]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('agentPrefix')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(resourceGroup().name, '-', parameters('agentPrefix'),'-lb')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/loadBalancers",
+      "name": "[parameters('agentPrefix')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/',parameters('agentPrefix'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "LoadBalancerFrontEnd",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('agentPrefix'))]"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "agentPool"
+          }
+        ],
+        "inboundNatPools": [
+          {
+            "name": "sshPool",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers',parameters('agentPrefix')),'/frontendIPConfigurations/loadBalancerFrontEnd')]"
+              },
+              "protocol": "tcp",
+              "frontendPortRangeStart": "[variables('natStartPort')]",
+              "frontendPortRangeEnd": "[variables('natEndPort')]",
+              "backendPort": "[variables('natBackendPort')]"
+            }
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "httpRule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers',parameters('agentPrefix')),'/frontendIPConfigurations/loadBalancerFrontEnd')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers',parameters('agentPrefix')),'/backendAddressPools/agentPool')]"
+              },
+              "protocol": "Tcp",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "enableFloatingIP": false,
+              "idleTimeoutInMinutes": 5,
+              "probe": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers',parameters('agentPrefix')),'/probes/tcpProbe')]"
+              }
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "tcpProbe",
+            "properties": {
+              "protocol": "Tcp",
+              "port": 22,
+              "intervalInSeconds": 10,
+              "numberOfProbes": 10
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "copy": {
+        "name": "clusterMasterNetworkSecurityGroup",
+        "count": "[parameters('masterCount')]"
+      },
+      "name": "[concat(parameters('masterPrefix'), copyIndex())]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-ssh",
+            "properties": {
+              "priority": 1000,
+              "sourceAddressPrefix": "*",
+              "protocol": "Tcp",
+              "destinationPortRange": "22",
+              "access": "Allow",
+              "direction": "Inbound",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/contrib/azure/genparams.py
+++ b/contrib/azure/genparams.py
@@ -1,22 +1,28 @@
+# Azure Template Parameter Packer
+# Takes username as first argument and outputs parameter JSON on stdout
+
 from base64 import b64encode
 from os import environ
 from json import dumps
 from os.path import exists, join
+from sys import argv, stderr, stdout
 
+USERNAME = argv[1].strip()
 OWN_PUBKEY = join(environ['HOME'],'.ssh','id_rsa.pub')
-GEN_PUBKEY = 'faas.pub'
+GEN_PUBKEY = USERNAME + '.pub'
 
 if exists(GEN_PUBKEY):
     admin_public_key = open(GEN_PUBKEY,'r').read()
 elif exists(OWN_PUBKEY):
     admin_public_key = open(OWN_PUBKEY,'r').read()
+    stderr.write('Warning: using %s instead of freshly generated keys.\n' % OWN_PUBKEY)
 else:
-    print('No public keys found, exiting.')
+    stderr.write('No public keys found, exiting.\n')
     exit(1)
 
 params = {
     "adminUsername": {
-        "value": "faas" # if you want to customize this, update the yml files too 
+        "value": USERNAME
     },
     "adminPublicKey": {
         "value": admin_public_key
@@ -44,5 +50,4 @@ params = {
     }
 }
 
-with open('faas-cluster-parameters.json', 'w') as h:
-    h.write(dumps(params))
+stdout.write(dumps(params))

--- a/contrib/azure/genparams.py
+++ b/contrib/azure/genparams.py
@@ -1,0 +1,48 @@
+from base64 import b64encode
+from os import environ
+from json import dumps
+from os.path import exists, join
+
+OWN_PUBKEY = join(environ['HOME'],'.ssh','id_rsa.pub')
+GEN_PUBKEY = 'faas.pub'
+
+if exists(GEN_PUBKEY):
+    admin_public_key = open(GEN_PUBKEY,'r').read()
+elif exists(OWN_PUBKEY):
+    admin_public_key = open(OWN_PUBKEY,'r').read()
+else:
+    print('No public keys found, exiting.')
+    exit(1)
+
+params = {
+    "adminUsername": {
+        "value": "faas" # if you want to customize this, update the yml files too 
+    },
+    "adminPublicKey": {
+        "value": admin_public_key
+    },
+    "masterCount": { 
+        "value": int(environ.get('MASTER_COUNT', 1))
+    },
+    "masterCustomData": {
+        "value": b64encode(open("cloud-config-master.yml", "r").read())
+    },
+    "agentCount": {
+        "value": int(environ.get('AGENT_COUNT', 2))
+    },
+    "agentCustomData": {
+        "value": b64encode(open("cloud-config-agent.yml", "r").read())
+    },
+    "masterSize": {
+        "value": "Standard_F1"
+    },
+    "agentSize": {
+        "value": "Standard_F1"
+    },
+    "saType": {
+        "value": "Standard_LRS"
+    }
+}
+
+with open('faas-cluster-parameters.json', 'w') as h:
+    h.write(dumps(params))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request adds a Resource Manager template for deploying FaaS on the Azure public cloud with automatic scaling of compute resources based on CPU load.

## Motivation and Context

This automates cloud infrastructure provisioning and paves the way to map function autoscaling to virtual machine autoscaling.

## How Has This Been Tested?

This is based on previous (well tested) work with minimal changes, and is usable from any Mac, Linux or Windows (with WSL) machine that has the Azure CLI installed.

It has no impact on existing code (and fetches all the Docker and Prometheus configs directly from the master branch)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.