### PR TITLE
Add X-Duration-Seconds measurement for all functions via watchdog

### DIFF
--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -42,6 +42,8 @@ func debugHeaders(source *http.Header, direction string) {
 }
 
 func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
+
 	parts := strings.Split(config.faasProcess, " ")
 
 	if config.debugHeaders {
@@ -102,6 +104,9 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 			w.Header().Set("Content-Type", clientContentType)
 		}
 	}
+
+	execTime := time.Since(startTime).Seconds()
+	w.Header().Set("X-Duration-Seconds", fmt.Sprintf("%f", execTime))
 
 	w.WriteHeader(200)
 	w.Write(out)

--- a/watchdog/requesthandler_test.go
+++ b/watchdog/requesthandler_test.go
@@ -20,6 +20,33 @@ func TestHandler_make(t *testing.T) {
 	}
 }
 
+func TestHandler_HasXDurationSecondsHeader(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	body := "hello"
+	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := WatchdogConfig{
+		faasProcess: "cat",
+	}
+	handler := makeRequestHandler(&config)
+	handler(rr, req)
+
+	required := http.StatusOK
+	if status := rr.Code; status != required {
+		t.Errorf("handler returned wrong status code: got %v, but wanted %v",
+			status, required)
+	}
+
+	seconds := rr.Header().Get("X-Duration-Seconds")
+	if len(seconds) == 0 {
+		t.Errorf("Exec of cat should have given a duration as an X-Duration-Seconds header\n")
+	}
+}
+
 func TestHandler_StatusOKAllowed_ForPOST(t *testing.T) {
 	rr := httptest.NewRecorder()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Measure watchdog function `exec` duration at execution point

## Motivation and Context

Provides mechanism to measure actual execution time of binary in `fprocess` variable.

`X-Duration-Seconds` will be returned in the HTTP Header.

## How Has This Been Tested?

```
./faas-cli -action=deploy -image=tester -name=tired -fprocess="sleep 1"
```

```
alexr:faas-cli alex$ curl localhost:8080/function/tired -d "test" -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> POST /function/tired HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.51.0
> Accept: */*
> Content-Length: 4
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 4 out of 4 bytes
< HTTP/1.1 200 OK
< Content-Length: 0
< Content-Type: application/x-www-form-urlencoded
< Date: Wed, 03 May 2017 07:57:43 GMT
< X-Duration-Seconds: 1.003150
< 
* Curl_http_done: called premature == 0
* Connection #0 to host localhost left intact
```

**< X-Duration-Seconds: 1.003150**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.