### PR TITLE
Add windows function

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,0 +1,25 @@
+version: "3"
+services:
+
+    # Calculates base64 representation of request body.
+    windows:
+        image: stefanscherer/base:golang-1.7.5-windows
+        labels:
+            function: "true"
+        depends_on:
+            - gateway
+        networks:
+            - functions
+        environment:
+            fprocess: "app.exe"
+            no_proxy: "gateway"
+            https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == windows]
+
+networks:
+    functions:
+        driver: overlay
+        # Docker does not support this option yet - maybe create outside of the stack and reference as "external"?
+        #attachable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         deploy:
             placement:
                 constraints: [node.role == manager]
- 
+
     prometheus:
         image: functions/prometheus:1.5.2 # Mirrors version 1.5.2 of quay.io/prometheus/prometheus:latest
         volumes:
@@ -66,6 +66,9 @@ services:
         environment:
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
     # Pass a username as an argument to find how many images user has pushed to Docker Hub.
     hubstats:
@@ -79,6 +82,9 @@ services:
         environment:
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
     # Node.js gives OS info about the node (Host)
     nodeinfo:
@@ -92,6 +98,9 @@ services:
         environment:
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
     # Uses `cat` to echo back response, fastest function to execute.
     echoit:
@@ -106,6 +115,9 @@ services:
             fprocess: "cat"
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
     # Counts words in request with `wc` utility
     wordcount:
@@ -121,6 +133,9 @@ services:
             fprocess: "wc"
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
     # Calculates base64 representation of request body.
     base64:
@@ -135,6 +150,9 @@ services:
             fprocess: "base64"
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
     # Decodes base64 representation of request body.
     decodebase64:
@@ -149,6 +167,9 @@ services:
             fprocess: "base64 -d"
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
     # Converts body in (markdown format) -> (html)
     markdown:
@@ -162,6 +183,9 @@ services:
         environment:
             no_proxy: "gateway"
             https_proxy: $https_proxy
+        deploy:
+            placement:
+                constraints: [node.platform.OS == linux]
 
 networks:
     functions:

--- a/sample-functions/BaseFunctions/golang/Dockerfile.win
+++ b/sample-functions/BaseFunctions/golang/Dockerfile.win
@@ -1,12 +1,16 @@
-FROM golang:1.7.5-windowsservercore
+FROM golang:1.7.5-windowsservercore AS build
 MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []
 
 WORKDIR /go/src/github.com/alexellis/faas/sample-functions/golang
-COPY . /go/src/github.com/alexellis/faas/sample-functions/golang
+COPY handler.go /go/src/github.com/alexellis/faas/sample-functions/golang/
 RUN go build
 
 ADD ./watchdog.exe /
+
+FROM microsoft/nanoserver
+COPY --from=build /watchdog.exe /watchdog.exe
+COPY --from=build /go/src/github.com/alexellis/faas/sample-functions/golang/golang.exe /app.exe
 
 EXPOSE 8080
 ENV fprocess="app.exe"


### PR DESCRIPTION
Add some `node.platform.OS` constraints to allow faas to run in a cross-platform swarm.
Run a first Windows function.

## How Has This Been Tested?
Create a cross-platform Docker swarm with eg. https://github.com/StefanScherer/docker-windows-box/tree/master/swarm-mode

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

<img width="1440" alt="faas-windows" src="https://cloud.githubusercontent.com/assets/207759/25746350/59d3b97e-31a3-11e7-80a8-6fdbf80e4129.png">