### PR TITLE
Move UI and support env-vars for functions

### DIFF
--- a/gateway/Dockerfile.multistage
+++ b/gateway/Dockerfile.multistage
@@ -18,8 +18,8 @@ EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-COPY --from 0 gateway    .
+COPY --from=0 /go/src/github.com/alexellis/faas/gateway/gateway    .
 
-COPY --from 0 assets     assets
+COPY assets     assets
 
 CMD ["./gateway"]

--- a/gateway/handlers/functionshandler.go
+++ b/gateway/handlers/functionshandler.go
@@ -198,6 +198,10 @@ func makeSpec(request *requests.CreateFunctionRequest) swarm.ServiceSpec {
 	if len(request.EnvProcess) > 0 {
 		env = append(env, fmt.Sprintf("fprocess=%s", request.EnvProcess))
 	}
+	for k, v := range request.EnvVars {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	if len(env) > 0 {
 		spec.TaskTemplate.ContainerSpec.Env = env
 	}

--- a/gateway/handlers/functionshandler.go
+++ b/gateway/handlers/functionshandler.go
@@ -174,11 +174,8 @@ func makeSpec(request *requests.CreateFunctionRequest) swarm.ServiceSpec {
 	max := uint64(1)
 
 	nets := []swarm.NetworkAttachmentConfig{
-		swarm.NetworkAttachmentConfig{Target: request.Network},
+		{Target: request.Network},
 	}
-
-	// TODO: request.EnvProcess should only be set if it's not nil, otherwise we override anything in the Docker image already
-
 	spec := swarm.ServiceSpec{
 		TaskTemplate: swarm.TaskSpec{
 			RestartPolicy: &swarm.RestartPolicy{
@@ -187,7 +184,6 @@ func makeSpec(request *requests.CreateFunctionRequest) swarm.ServiceSpec {
 			},
 			ContainerSpec: swarm.ContainerSpec{
 				Image:  request.Image,
-				Env:    []string{fmt.Sprintf("fprocess=%s", request.EnvProcess)},
 				Labels: map[string]string{"function": "true"},
 			},
 			Networks: nets,
@@ -196,5 +192,15 @@ func makeSpec(request *requests.CreateFunctionRequest) swarm.ServiceSpec {
 			Name: request.Service,
 		},
 	}
+
+	// TODO: request.EnvProcess should only be set if it's not nil, otherwise we override anything in the Docker image already
+	var env []string
+	if len(request.EnvProcess) > 0 {
+		env = append(env, fmt.Sprintf("fprocess=%s", request.EnvProcess))
+	}
+	if len(env) > 0 {
+		spec.TaskTemplate.ContainerSpec.Env = env
+	}
+
 	return spec
 }

--- a/gateway/metrics/swarmwatcher.go
+++ b/gateway/metrics/swarmwatcher.go
@@ -15,7 +15,7 @@ import (
 
 // AttachSwarmWatcher adds a go-route to monitor the amount of service replicas in the swarm
 // matching a 'function' label.
-func AttachSwarmWatcher(dockerClient *client.Client, metricsOptions MetricOptions) {
+func AttachSwarmWatcher(dockerClient *client.Client, metricsOptions MetricOptions, label string) {
 	ticker := time.NewTicker(1 * time.Second)
 	quit := make(chan struct{})
 
@@ -35,7 +35,7 @@ func AttachSwarmWatcher(dockerClient *client.Client, metricsOptions MetricOption
 				}
 
 				for _, service := range services {
-					if len(service.Spec.TaskTemplate.ContainerSpec.Labels["function"]) > 0 {
+					if len(service.Spec.TaskTemplate.ContainerSpec.Labels[label]) > 0 {
 						metricsOptions.ServiceReplicasCounter.
 							WithLabelValues(service.Spec.Name).
 							Set(float64(*service.Spec.Mode.Replicated.Replicas))

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -5,9 +5,9 @@ package requests
 
 // CreateFunctionRequest create a function in the swarm.
 type CreateFunctionRequest struct {
-	Service    string `json:"service"`
-	Image      string `json:"image"`
-	Network    string `json:"network"`
+	Service string `json:"service"`
+	Image   string `json:"image"`
+	Network string `json:"network"`
 
 	// EnvProcess corresponds to the fprocess variable for your container watchdog.
 	EnvProcess string `json:"envProcess"`

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -5,8 +5,12 @@ package requests
 
 // CreateFunctionRequest create a function in the swarm.
 type CreateFunctionRequest struct {
+	// Service corresponds to a Docker Service
 	Service string `json:"service"`
-	Image   string `json:"image"`
+	// Image corresponds to a Docker image
+	Image string `json:"image"`
+
+	// Network is a Docker overlay network in Swarm - the default value is func_functions
 	Network string `json:"network"`
 
 	// EnvProcess corresponds to the fprocess variable for your container watchdog.


### PR DESCRIPTION
## Description

Move UI to /ui/ URL-space and support env-vars for functions

## Motivation and Context

* Having a specific URI for the UI will help with securing via a reverse proxy.
* Env-vars for functions allows for easy configuration

## How Has This Been Tested?

* Env-vars tested on Linux with Slack functions via faas-cli and YAML file.
* UI tested on Mac through Safari

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
