### PR TITLE
Handle private docker registry auth

### DIFF
--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -155,6 +155,9 @@ definitions:
         items:
           type: "string"
         description: "Overrides to environmental variables"
+      registryAuth:
+        type: "string"
+        description: "Private registry base64-encoded basic auth (as present in ~/.docker/config.json)"
 externalDocs:
   description: "More documentation available on Github"
   url: "http://docs.get-faas.com"

--- a/docs/managing-images.md
+++ b/docs/managing-images.md
@@ -1,0 +1,86 @@
+# Managing images
+
+## Using private Docker registries
+
+FaaS supports running functions from Docker images in private Docker registries.
+The registry credentials can be passed on function deployment, and are then handled by Swarm for image polling.
+
+### Deploy functions with private registries credentials
+
+A `POST` request on `/system/function` allows you to specify private registry credentials, as a base64-encoded basic auth (user:password).
+```
+curl -XPOST /system/functions -d {
+    "service": "functionName",
+    "image": "privateregistry.domain.com/user/function",
+    "envProcess": "/usr/bin/myprocess",
+    "network": "func_functions",
+    "registryAuth": "dXNlcjpwYXNzd29yZA=="
+}
+```
+
+Base64-encoded basic auth can be resolved using your registry username and password:
+````
+echo -n "user:password" | base64
+````
+
+You can also find it in your `~/.docker/config.json` Docker credentials store, as a result of the `docker login` command:
+```
+cat ~/.docker/config.json
+{
+	"auths": {
+		"privateregistry.domain.com": {
+			"auth": "dXNlcjpwYXNzd29yZA=="
+		}
+	}
+}
+```
+
+### Deploy your own private Docker registry
+
+If you wish to deploy your own private registry, you can follow [Docker official documentation](https://docs.docker.com/registry/deploying/).
+
+A quick way to get started for a private registry with TLS and authentication
+is to create a VM with port 443 open to the world (for letsencrypt registration), and a registered DNS ($YOURHOST).
+Then, create these two files in the current directory:
+
+```
+# docker-compose.yml
+version: '2'
+
+services:
+
+  registry:
+    restart: always
+    image: registry:2
+    ports:
+      - 5000:5000
+      - 443:5000
+    environment:
+      REGISTRY_AUTH: htpasswd
+      REGISTRY_AUTH_HTPASSWD_PATH: /auth/htpasswd
+      REGISTRY_AUTH_HTPASSWD_REALM: Registry Realm
+      REGISTRY_HTTP_TLS_LETSENCRYPT_CACHEFILE: /letsencrypt/cache
+      REGISTRY_HTTP_TLS_LETSENCRYPT_EMAIL: your@email.com
+    volumes:
+      - ./data:/var/lib/registry
+      - ./auth:/auth
+      - ./letsencrypt:/letsencrypt
+```
+
+```
+# auth/htpasswd (generated with `docker run --entrypoint htpasswd registry:2 -Bbn testuser testpassword`)
+testuser:$2y$05$Bl9siDMe7ieQHLM8e7ifaOklKrHmXymbMqfmqXs7zssj6MMGQW4le
+```
+
+Your registry is ready to be deployed by running `docker-compose up -d`.
+
+On the client machine, you can now login and use the newly setup registry:
+```
+docker pull ubuntu && docker tag ubuntu $YOURHOST/ubuntu
+docker login $YOURHOST # will add encoded registry credentials to ~/.docker/config.json
+    Username: testuser
+    Password: testpassword
+docker push $YOURHOST/ubuntu
+```
+
+Images pushed to this registry can be used as functions with FaaS, provided you pass the appropriate `registryAuth` parameter at deployment time.

--- a/gateway/Dockerfile.build
+++ b/gateway/Dockerfile.build
@@ -18,4 +18,5 @@ COPY requests   requests
 COPY tests      tests
 COPY server.go  .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+RUN go test -v ./tests && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .

--- a/gateway/Dockerfile.build.armhf
+++ b/gateway/Dockerfile.build.armhf
@@ -17,4 +17,5 @@ COPY handlers	handlers
 
 COPY server.go	.
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+RUN go test -v ./tests && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -18,6 +18,11 @@ type CreateFunctionRequest struct {
 
 	// EnvVars provides overrides for functions.
 	EnvVars map[string]string `json:"envVars"`
+
+	// RegistryAuth is the registry authentication (optional)
+	// in the same encoded format as Docker native credentials
+	// (see ~/.docker/config.json)
+	RegistryAuth string `json:"registryAuth,omitempty"`
 }
 
 type DeleteFunctionRequest struct {

--- a/gateway/tests/registryauth_test.go
+++ b/gateway/tests/registryauth_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package tests
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/alexellis/faas/gateway/handlers"
+	"github.com/docker/docker/api/types"
+)
+
+func TestBuildEncodedAuthConfig(t *testing.T) {
+	// custom repository with valid data
+	assertValidEncodedAuthConfig(t, "user", "password", "my.repository.com/user/imagename", "my.repository.com")
+	assertValidEncodedAuthConfig(t, "user", "weird:password:", "my.repository.com/user/imagename", "my.repository.com")
+	assertValidEncodedAuthConfig(t, "userWithNoPassword", "", "my.repository.com/user/imagename", "my.repository.com")
+	assertValidEncodedAuthConfig(t, "", "", "my.repository.com/user/imagename", "my.repository.com")
+
+	// docker hub default repository
+	assertValidEncodedAuthConfig(t, "user", "password", "user/imagename", "docker.io")
+	assertValidEncodedAuthConfig(t, "", "", "user/imagename", "docker.io")
+
+	// invalid base64 basic auth
+	assertEncodedAuthError(t, "invalidBasicAuth", "my.repository.com/user/imagename")
+
+	// invalid docker image name
+	assertEncodedAuthError(t, b64BasicAuth("user", "password"), "")
+	assertEncodedAuthError(t, b64BasicAuth("user", "password"), "invalid name")
+}
+
+func assertValidEncodedAuthConfig(t *testing.T, user, password, imageName, expectedRegistryHost string) {
+	encodedAuthConfig, err := handlers.BuildEncodedAuthConfig(b64BasicAuth(user, password), imageName)
+	if err != nil {
+		t.Log("Unexpected error while building auth config with correct values")
+		t.Fail()
+	}
+
+	authConfig := &types.AuthConfig{}
+	authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(encodedAuthConfig))
+	if err := json.NewDecoder(authJSON).Decode(authConfig); err != nil {
+		t.Log("Invalid encoded auth", err)
+		t.Fail()
+	}
+
+	if user != authConfig.Username {
+		t.Log("Auth config username mismatch", user, authConfig.Username)
+		t.Fail()
+	}
+	if password != authConfig.Password {
+		t.Log("Auth config password mismatch", password, authConfig.Password)
+		t.Fail()
+	}
+	if expectedRegistryHost != authConfig.ServerAddress {
+		t.Log("Auth config registry server address mismatch", expectedRegistryHost, authConfig.ServerAddress)
+		t.Fail()
+	}
+}
+
+func assertEncodedAuthError(t *testing.T, b64BasicAuth, imageName string) {
+	_, err := handlers.BuildEncodedAuthConfig(b64BasicAuth, imageName)
+	if err == nil {
+		t.Log("Expected an error to be returned")
+		t.Fail()
+	}
+}
+
+func b64BasicAuth(user, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(user + ":" + password))
+}


### PR DESCRIPTION
This adds support for private docker registries.

## Description
An optional `registryAuth` field in the CreateFunctionRequest
allows users to specify a registry auth to be used for deployment.

Auth must be passed as base64-encoded basic auth, similar to
how it's done in Docker file store credentials (~/.docker/config.json).

Credentials are then passed to swarm at service creation.

## Motivation and Context
Support for private registries.
See issue #83 

## How Has This Been Tested?
Manual test procedure:
1) deploy a private registry with basic auth enabled (see https://gist.github.com/sebgl/3c97c379ddc77c65c44d47e6b745fa10)
2) push a docker image to the private registry
3) deploy a function with `"registryAuth": "base64user:password"`

Automated integration tests are a bit harder to perform due to the
need for a private registry with TLS + basic auth.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

A few things I'd like to point out:
* The only documentation I have updated is `api-docs/swagger.yml`. I'm not sure that's enough. Should we include additional documentation somewhere?
* In order to stay close to the authentication system set up with Docker credentials (`~/.docker/config.json`), the deploy API accepts a base64-encoded basic auth. This might be a bit confusing.
* As discussed with Alex, the web UI has not be updated to match this change for now.