### PR TITLE
Gateway Configuration with Timeouts

### DIFF
--- a/gateway/Dockerfile.build
+++ b/gateway/Dockerfile.build
@@ -18,8 +18,6 @@ COPY requests       requests
 COPY tests          tests
 COPY server.go      .
 COPY readconfig.go  .
-COPY config_test.go .
 
-RUN go test && \
-    go test -v ./tests && \
+RUN go test -v ./tests && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .

--- a/gateway/Dockerfile.build
+++ b/gateway/Dockerfile.build
@@ -10,13 +10,16 @@ FROM golang:1.7.5
 
 WORKDIR /go/src/github.com/alexellis/faas/gateway
 
-COPY vendor     vendor
+COPY vendor         vendor
 
-COPY handlers   handlers
-COPY metrics    metrics
-COPY requests   requests
-COPY tests      tests
-COPY server.go  .
+COPY handlers       handlers
+COPY metrics        metrics
+COPY requests       requests
+COPY tests          tests
+COPY server.go      .
+COPY readconfig.go  .
+COPY config_test.go .
 
-RUN go test -v ./tests && \
+RUN go test && \
+    go test -v ./tests && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .

--- a/gateway/Dockerfile.build.armhf
+++ b/gateway/Dockerfile.build.armhf
@@ -17,8 +17,6 @@ COPY handlers       handlers
 
 COPY server.go      .
 COPY readconfig.go  .
-COPY config_test.go .
 
-RUN go test && \
-    go test -v ./tests && \
+RUN go test -v ./tests && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .

--- a/gateway/Dockerfile.build.armhf
+++ b/gateway/Dockerfile.build.armhf
@@ -10,12 +10,15 @@ RUN go get -d github.com/Sirupsen/logrus
 
 WORKDIR /go/src/github.com/alexellis/faas/gateway
 
-COPY metrics	metrics
-COPY requests	requests
-COPY tests	tests
-COPY handlers	handlers
+COPY metrics        metrics
+COPY requests       requests
+COPY tests          tests
+COPY handlers       handlers
 
-COPY server.go	.
+COPY server.go      .
+COPY readconfig.go  .
+COPY config_test.go .
 
-RUN go test -v ./tests && \
+RUN go test && \
+    go test -v ./tests && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .

--- a/gateway/Dockerfile.multistage
+++ b/gateway/Dockerfile.multistage
@@ -9,7 +9,6 @@ COPY requests       requests
 COPY tests          tests
 COPY server.go      .
 COPY readconfig.go  .
-COPY config_test.go .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gateway .
 

--- a/gateway/Dockerfile.multistage
+++ b/gateway/Dockerfile.multistage
@@ -1,13 +1,15 @@
 FROM golang:1.7.5
 WORKDIR /go/src/github.com/alexellis/faas/gateway
 
-COPY vendor     vendor
+COPY vendor         vendor
 
-COPY handlers	handlers
-COPY metrics	metrics
-COPY requests	requests
-COPY tests      tests
-COPY server.go  .
+COPY handlers       handlers
+COPY metrics        metrics
+COPY requests       requests
+COPY tests          tests
+COPY server.go      .
+COPY readconfig.go  .
+COPY config_test.go .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gateway .
 

--- a/gateway/Dockerfile.newbuild
+++ b/gateway/Dockerfile.newbuild
@@ -2,13 +2,15 @@ FROM golang:1.7.5
 # RUN mkdir -p /go/src/github.com/alexellis/faas/gateway
 WORKDIR /go/src/github.com/alexellis/faas/gateway
 
-COPY vendor     vendor
+COPY vendor         vendor
 
-COPY handlers	handlers
-COPY metrics	metrics
-COPY requests	requests
-COPY tests      tests
-COPY server.go  .
+COPY handlers       handlers
+COPY metrics        metrics
+COPY requests       requests
+COPY tests          tests
+COPY server.go      .
+COPY readconfig.go  .
+COPY config_test.go .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gateway .
 

--- a/gateway/Dockerfile.newbuild
+++ b/gateway/Dockerfile.newbuild
@@ -10,7 +10,6 @@ COPY requests       requests
 COPY tests          tests
 COPY server.go      .
 COPY readconfig.go  .
-COPY config_test.go .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gateway .
 

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+type EnvBucket struct {
+	Items map[string]string
+}
+
+func NewEnvBucket() EnvBucket {
+	return EnvBucket{
+		Items: make(map[string]string),
+	}
+}
+
+func (e EnvBucket) Getenv(key string) string {
+	return e.Items[key]
+}
+
+func (e EnvBucket) Setenv(key string, value string) {
+	e.Items[key] = value
+}
+
+func TestRead_EmptyTimeoutConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+
+	config := readConfig.Read(defaults)
+
+	if (config.readTimeout) != time.Duration(8)*time.Second {
+		t.Log("readTimeout incorrect")
+		t.Fail()
+	}
+	if (config.writeTimeout) != time.Duration(8)*time.Second {
+		t.Log("writeTimeout incorrect")
+		t.Fail()
+	}
+}
+
+func TestRead_ReadAndWriteTimeoutConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("read_timeout", "10")
+	defaults.Setenv("write_timeout", "60")
+
+	readConfig := ReadConfig{}
+	config := readConfig.Read(defaults)
+
+	if (config.readTimeout) != time.Duration(10)*time.Second {
+		t.Logf("readTimeout incorrect, got: %d\n", config.readTimeout)
+		t.Fail()
+	}
+	if (config.writeTimeout) != time.Duration(60)*time.Second {
+		t.Logf("writeTimeout incorrect, got: %d\n", config.writeTimeout)
+		t.Fail()
+	}
+}

--- a/gateway/readconfig.go
+++ b/gateway/readconfig.go
@@ -48,14 +48,14 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 	readTimeout := parseIntValue(hasEnv.Getenv("read_timeout"), 8)
 	writeTimeout := parseIntValue(hasEnv.Getenv("write_timeout"), 8)
 
-	cfg.readTimeout = time.Duration(readTimeout) * time.Second
-	cfg.writeTimeout = time.Duration(writeTimeout) * time.Second
+	cfg.ReadTimeout = time.Duration(readTimeout) * time.Second
+	cfg.WriteTimeout = time.Duration(writeTimeout) * time.Second
 
 	return cfg
 }
 
 // GatewayConfig for the process.
 type GatewayConfig struct {
-	readTimeout  time.Duration
-	writeTimeout time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
 }

--- a/gateway/readconfig.go
+++ b/gateway/readconfig.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// OsEnv implements interface to wrap os.Getenv
+type OsEnv struct {
+}
+
+// Getenv wraps os.Getenv
+func (OsEnv) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// HasEnv provides interface for os.Getenv
+type HasEnv interface {
+	Getenv(key string) string
+}
+
+// ReadConfig constitutes config from env variables
+type ReadConfig struct {
+}
+
+func parseBoolValue(val string) bool {
+	if val == "true" {
+		return true
+	}
+	return false
+}
+
+func parseIntValue(val string, fallback int) int {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return parsedVal
+		}
+	}
+	return fallback
+}
+
+// Read fetches config from environmental variables.
+func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
+	cfg := GatewayConfig{}
+
+	readTimeout := parseIntValue(hasEnv.Getenv("read_timeout"), 8)
+	writeTimeout := parseIntValue(hasEnv.Getenv("write_timeout"), 8)
+
+	cfg.readTimeout = time.Duration(readTimeout) * time.Second
+	cfg.writeTimeout = time.Duration(writeTimeout) * time.Second
+
+	return cfg
+}
+
+// GatewayConfig for the process.
+type GatewayConfig struct {
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -23,8 +23,8 @@ func main() {
 	readConfig := ReadConfig{}
 	config := readConfig.Read(osEnv)
 
-	log.Printf("HTTP Read Timeout: %s", config.readTimeout)
-	log.Printf("HTTP Write Timeout: %s", config.writeTimeout)
+	log.Printf("HTTP Read Timeout: %s", config.ReadTimeout)
+	log.Printf("HTTP Write Timeout: %s", config.WriteTimeout)
 
 	var dockerClient *client.Client
 	var err error
@@ -71,8 +71,8 @@ func main() {
 
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", tcpPort),
-		ReadTimeout:    config.readTimeout,
-		WriteTimeout:   config.writeTimeout,
+		ReadTimeout:    config.ReadTimeout,
+		WriteTimeout:   config.WriteTimeout,
 		MaxHeaderBytes: http.DefaultMaxHeaderBytes, // 1MB - can be overridden by setting Server.MaxHeaderBytes.
 		Handler:        r,
 	}

--- a/gateway/tests/config_test.go
+++ b/gateway/tests/config_test.go
@@ -1,11 +1,13 @@
 // Copyright (c) Alex Ellis 2017. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-package main
+package tests
 
 import (
 	"testing"
 	"time"
+
+	gateway "github.com/alexellis/faas/gateway"
 )
 
 type EnvBucket struct {
@@ -28,16 +30,16 @@ func (e EnvBucket) Setenv(key string, value string) {
 
 func TestRead_EmptyTimeoutConfig(t *testing.T) {
 	defaults := NewEnvBucket()
-	readConfig := ReadConfig{}
+	readConfig := gateway.ReadConfig{}
 
 	config := readConfig.Read(defaults)
 
-	if (config.readTimeout) != time.Duration(8)*time.Second {
-		t.Log("readTimeout incorrect")
+	if (config.ReadTimeout) != time.Duration(8)*time.Second {
+		t.Log("ReadTimeout incorrect")
 		t.Fail()
 	}
-	if (config.writeTimeout) != time.Duration(8)*time.Second {
-		t.Log("writeTimeout incorrect")
+	if (config.WriteTimeout) != time.Duration(8)*time.Second {
+		t.Log("WriteTimeout incorrect")
 		t.Fail()
 	}
 }
@@ -47,15 +49,15 @@ func TestRead_ReadAndWriteTimeoutConfig(t *testing.T) {
 	defaults.Setenv("read_timeout", "10")
 	defaults.Setenv("write_timeout", "60")
 
-	readConfig := ReadConfig{}
+	readConfig := gateway.ReadConfig{}
 	config := readConfig.Read(defaults)
 
-	if (config.readTimeout) != time.Duration(10)*time.Second {
-		t.Logf("readTimeout incorrect, got: %d\n", config.readTimeout)
+	if (config.ReadTimeout) != time.Duration(10)*time.Second {
+		t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
 		t.Fail()
 	}
-	if (config.writeTimeout) != time.Duration(60)*time.Second {
-		t.Logf("writeTimeout incorrect, got: %d\n", config.writeTimeout)
+	if (config.WriteTimeout) != time.Duration(60)*time.Second {
+		t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
New feature for Gateway Configuration Options

## Description

- Adds GatewayConfig
- Env configurable `read_timeout` & `write_timeout` /w test copied over from watchdog.
- Moves httpPort definition to the config default declaration.
- Modifies Dockerfiles to add new files and test code.
- Adds runtime logging for options.

## Motivation and Context
Resolves #95 and #94 

## How Has This Been Tested?
Unit test and config were included in the `main` package instead of the `tests` folder because of access to unexported struct members.
The additional test gates the build.
This follows the same format as the watchdog.

I tested e2e functionality by setting the `read_timeout` and `write_timeout` ENV vars on the gateway container, checking the new log output, and following the steps in #94.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
