### PR TITLE
Fix Watchdog Timeouts - duplicate multiplication of `time.Second`

### DIFF
--- a/watchdog/build.sh
+++ b/watchdog/build.sh
@@ -7,7 +7,7 @@ if [ ! $http_proxy == "" ]
 then
     docker build --no-cache --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -t functions/watchdog:build .
 else
-    docker build -t functions/watchdog:build .
+    docker build --no-cache -t functions/watchdog:build .
 fi
 
 docker create --name buildoutput functions/watchdog:build echo

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -147,13 +147,10 @@ func main() {
 		return
 	}
 
-	readTimeout := time.Duration(config.readTimeout) * time.Second
-	writeTimeout := time.Duration(config.writeTimeout) * time.Second
-
 	s := &http.Server{
 		Addr:           ":8080",
-		ReadTimeout:    readTimeout,
-		WriteTimeout:   writeTimeout,
+		ReadTimeout:    config.readTimeout,
+		WriteTimeout:   config.writeTimeout,
 		MaxHeaderBytes: 1 << 20,
 	}
 


### PR DESCRIPTION
Removed duplicate multiplication of `time.Second` in *main.go*.
Resolves #97 

<!--- Provide a general summary of your changes in the Title above -->

## Description
Times are already parsed as ints and multiplied by seconds before they are stored in the config struct as Durations.
They do not need further calculation when being passed to the httpServer, so the code has been removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Functions should terminate within a timely fashion.
Currently, the timeout is much much much longer than expected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
#### sleeper function using `functions/alpine:health` with the default timeout of 5s:
```bash
λ curl localhost:8080/function/func_sleeper -XPOST -d7   # does not timeout
hi, sleeping for: 7
done
```

#### sleeper function using a fresh `functions/watchdog:build` with the deafult timeout:
```bash
λ curl localhost:8080/function/func_sleeper -XPOST -d2
hi, sleeping for: 2
done

λ curl localhost:8080/function/func_sleeper -XPOST -d5   # times out
Can't reach service: func_sleeper

λ curl localhost:8080/function/func_sleeper -XPOST -d4
hi, sleeping for: 4
done
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


## PS:
I've also added `--no-cache` to the dockerfile for when there is no `$http_proxy`.
This may or may not be desireable.