### PR TITLE
Watchdog refurbishments

### DIFF
--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -3,7 +3,7 @@ Watchdog
 
 The FaaS watchdog is designed to marshal a HTTP request between your public HTTP URL and a individual function.
 
-Every FaaS function embeds this binary and uses it as its entrypoint.
+Every FaaS function should embed this binary and uses it as its entrypoint. It is in effect a tiny web-server or shim that will fork your desired process for every HTTP request.
 
 Creating a function:
 
@@ -54,15 +54,66 @@ A number of environmental overrides can be added for additional flexibility and 
 | Option                 | Usage             |
 |------------------------|--------------|
 | `fprocess`             | The process to invoke for each function call. This must be a UNIX binary and accept input via STDIN and output via STDOUT.  |
-| `cgi_headers`          | HTTP headers from request are made available through environmental variables - `Http_X-Served-By` etc. |
+| `cgi_headers`          | HTTP headers from request are made available through environmental variables - `Http_X-Served-By` etc. See section: *Handling headers* for more detail. Enabled by default. |
 | `marshal_requests`     | Instead of re-directing the raw HTTP body into your fprocess, it will first be marshalled into JSON. Use this if you need to work with HTTP headers and do not want to use environmental variables via the `cgi_headers` flag. |
-| `content_type`         | Force a specific Content-Type response for all responses.    |
-| `write_timeout`        | HTTP timeout for writing a response body from your function  |
-| `read_timeout`         | HTTP timeout for reading the payload from the client caller  |
+| `content_type`         | Force a specific Content-Type response for all responses. |
+| `write_timeout`        | HTTP timeout for writing a response body from your function (in seconds)  |
+| `read_timeout`         | HTTP timeout for reading the payload from the client caller (in seconds) |
 | `suppress_lock`        | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
+| `exec_timeout`         | Hard timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0. |
  
 
 ## Advanced / tuning
+
+**Handling headers**
+
+You can get hold of the HTTP headers by enabling the `cgi_headers` environmental variable.
+
+Here's an example of a POST request with an additional header and a query-string.
+
+```
+$ cgi_headers=true fprocess=env ./watchdog &
+2017/06/23 17:02:58 Writing lock-file to: /tmp/.lock
+
+$ curl "localhost:8080?q=serverless&page=1" -X POST -H X-Forwarded-By:http://my.vpn.com
+```
+
+This is what you'd see if you had set your `fprocess` to `env` on a Linux system:
+
+```
+Http_User-Agent=curl/7.43.0
+Http_Accept=*/*
+Http_X-Forwarded-By=http://my.vpn.com
+Http_Method=POST
+Http_Query=q=serverless&page=1
+```
+
+You can also use the `GET` verb:
+
+```
+$ curl "localhost:8080?action=quote&qty=1&productId=105"
+```
+
+The output from the watchdog would be:
+
+```
+Http_User-Agent=curl/7.43.0
+Http_Accept=*/*
+Http_Method=GET
+Http_Query=action=quote&qty=1&productId=105
+```
+
+You can now use HTTP state from within your application to make decisions.
+
+**HTTP methods**
+
+The HTTP methods supported for the watchdog are:
+
+With a body:
+* POST, PUT, DELETE, UPDATE
+
+Without a body:
+* GET
 
 **Content-Type of request/response**
 

--- a/watchdog/config_test.go
+++ b/watchdog/config_test.go
@@ -25,6 +25,32 @@ func (e EnvBucket) Getenv(key string) string {
 func (e EnvBucket) Setenv(key string, value string) {
 	e.Items[key] = value
 }
+
+func TestRead_CgiHeaders_OverideFalse(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+	defaults.Setenv("cgi_headers", "false")
+
+	config := readConfig.Read(defaults)
+
+	if config.cgiHeaders != false {
+		t.Logf("cgiHeaders should have been false (via env)")
+		t.Fail()
+	}
+}
+
+func TestRead_CgiHeaders_DefaultIsTrueConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+
+	config := readConfig.Read(defaults)
+
+	if config.cgiHeaders != true {
+		t.Logf("cgiHeaders should have been true (unspecified)")
+		t.Fail()
+	}
+}
+
 func TestRead_WriteDebug_DefaultIsTrueConfig(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := ReadConfig{}
@@ -132,6 +158,20 @@ func TestRead_ReadAndWriteTimeoutConfig(t *testing.T) {
 	}
 	if (config.writeTimeout) != time.Duration(60)*time.Second {
 		t.Logf("writeTimeout incorrect, got: %d\n", config.writeTimeout)
+		t.Fail()
+	}
+}
+
+func TestRead_ExecTimeoutConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("exec_timeout", "3")
+
+	readConfig := ReadConfig{}
+	config := readConfig.Read(defaults)
+
+	want := time.Duration(3) * time.Second
+	if (config.execTimeout) != want {
+		t.Logf("readTimeout incorrect, got: %d - want: %s\n", config.execTimeout, want)
 		t.Fail()
 	}
 }

--- a/watchdog/config_test.go
+++ b/watchdog/config_test.go
@@ -26,7 +26,7 @@ func (e EnvBucket) Setenv(key string, value string) {
 	e.Items[key] = value
 }
 
-func TestRead_CgiHeaders_OverideFalse(t *testing.T) {
+func TestRead_CgiHeaders_OverrideFalse(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := ReadConfig{}
 	defaults.Setenv("cgi_headers", "false")

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -23,8 +23,11 @@ func buildFunctionInput(config *WatchdogConfig, r *http.Request) ([]byte, error)
 	var requestBytes []byte
 	var err error
 
-	defer r.Body.Close()
-	requestBytes, _ = ioutil.ReadAll(r.Body)
+	if r.Body != nil {
+		defer r.Body.Close()
+	}
+
+	requestBytes, err = ioutil.ReadAll(r.Body)
 	if config.marshalRequest {
 		marshalRes, marshalErr := types.MarshalRequest(requestBytes, &r.Header)
 		err = marshalErr
@@ -41,10 +44,16 @@ func debugHeaders(source *http.Header, direction string) {
 	}
 }
 
-func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request) {
+type requestInfo struct {
+	headerWritten bool
+}
+
+func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request, method string, hasBody bool) {
 	startTime := time.Now()
 
 	parts := strings.Split(config.faasProcess, " ")
+
+	ri := &requestInfo{}
 
 	if config.debugHeaders {
 		debugHeaders(&r.Header, "in")
@@ -52,12 +61,8 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 
 	targetCmd := exec.Command(parts[0], parts[1:]...)
 
-	if config.cgiHeaders {
-		envs := os.Environ()
-		for k, v := range r.Header {
-			kv := fmt.Sprintf("Http_%s=%s", k, v[0])
-			envs = append(envs, kv)
-		}
+	envs := getAdditionalEnvs(config, r, method)
+	if len(envs) > 0 {
 		targetCmd.Env = envs
 	}
 
@@ -65,24 +70,59 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 
 	var out []byte
 	var err error
-	var res []byte
+	var requestBody []byte
 
 	var wg sync.WaitGroup
-	wg.Add(2)
 
-	res, buildInputErr := buildFunctionInput(config, r)
-	if buildInputErr != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(buildInputErr.Error()))
-		return
+	wgCount := 2
+	if hasBody == false {
+		wgCount = 1
 	}
 
-	// Write to pipe in separate go-routine to prevent blocking
-	go func() {
-		defer wg.Done()
-		writer.Write(res)
-		writer.Close()
-	}()
+	if hasBody {
+		var buildInputErr error
+		requestBody, buildInputErr = buildFunctionInput(config, r)
+		if buildInputErr != nil {
+			ri.headerWritten = true
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(buildInputErr.Error()))
+			return
+		}
+	}
+
+	wg.Add(wgCount)
+
+	var timer *time.Timer
+
+	if config.execTimeout > 0*time.Second {
+		timer = time.NewTimer(config.execTimeout)
+
+		go func() {
+			<-timer.C
+			log.Printf("Killing process: %s\n", config.faasProcess)
+			if targetCmd != nil && targetCmd.Process != nil {
+				ri.headerWritten = true
+				w.WriteHeader(http.StatusRequestTimeout)
+
+				w.Write([]byte("Killed process.\n"))
+
+				val := targetCmd.Process.Kill()
+				if val != nil {
+					log.Printf("Killed process: %s - error %s\n", config.faasProcess, val.Error())
+				}
+			}
+		}()
+	}
+
+	// Only write body if this is appropriate for the method.
+	if hasBody {
+		// Write to pipe in separate go-routine to prevent blocking
+		go func() {
+			defer wg.Done()
+			writer.Write(requestBody)
+			writer.Close()
+		}()
+	}
 
 	go func() {
 		defer wg.Done()
@@ -90,16 +130,25 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 	}()
 
 	wg.Wait()
+	if timer != nil {
+		timer.Stop()
+	}
 
 	if err != nil {
 		if config.writeDebug == true {
-			log.Println(targetCmd, err)
+			log.Printf("Success=%t, Error=%s\n", targetCmd.ProcessState.Success(), err.Error())
+			log.Printf("Out=%s\n", out)
 		}
-		w.WriteHeader(500)
-		response := bytes.NewBufferString(err.Error())
-		w.Write(response.Bytes())
+
+		if ri.headerWritten == false {
+			w.WriteHeader(http.StatusInternalServerError)
+			response := bytes.NewBufferString(err.Error())
+			w.Write(response.Bytes())
+			ri.headerWritten = true
+		}
 		return
 	}
+
 	if config.writeDebug == true {
 		os.Stdout.Write(out)
 	}
@@ -115,11 +164,13 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	execTime := time.Since(startTime).Seconds()
-	w.Header().Set("X-Duration-Seconds", fmt.Sprintf("%f", execTime))
-
-	w.WriteHeader(200)
-	w.Write(out)
+	if ri.headerWritten == false {
+		execTime := time.Since(startTime).Seconds()
+		w.Header().Set("X-Duration-Seconds", fmt.Sprintf("%f", execTime))
+		ri.headerWritten = true
+		w.WriteHeader(200)
+		w.Write(out)
+	}
 
 	if config.debugHeaders {
 		header := w.Header()
@@ -127,12 +178,42 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request)
 	}
 }
 
+func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) []string {
+	var envs []string
+
+	if config.cgiHeaders {
+		envs = os.Environ()
+		for k, v := range r.Header {
+			kv := fmt.Sprintf("Http_%s=%s", k, v[0])
+			envs = append(envs, kv)
+		}
+		envs = append(envs, fmt.Sprintf("Http_Method=%s", method))
+
+		if len(r.URL.RawQuery) > 0 {
+			envs = append(envs, fmt.Sprintf("Http_Query=%s", r.URL.RawQuery))
+		}
+	}
+
+	return envs
+}
+
 func makeRequestHandler(config *WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" {
-			pipeRequest(config, w, r)
-		} else {
+		switch r.Method {
+		case
+			"POST",
+			"PUT",
+			"DELETE",
+			"UPDATE":
+			pipeRequest(config, w, r, r.Method, true)
+			break
+		case
+			"GET":
+			pipeRequest(config, w, r, r.Method, false)
+			break
+		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
+
 		}
 	}
 }
@@ -147,14 +228,14 @@ func main() {
 		return
 	}
 
-	readTimeout := time.Duration(config.readTimeout) * time.Second
-	writeTimeout := time.Duration(config.writeTimeout) * time.Second
+	readTimeout := config.readTimeout
+	writeTimeout := config.writeTimeout
 
 	s := &http.Server{
 		Addr:           ":8080",
 		ReadTimeout:    readTimeout,
 		WriteTimeout:   writeTimeout,
-		MaxHeaderBytes: 1 << 20,
+		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 
 	http.HandleFunc("/", makeRequestHandler(&config))
@@ -164,9 +245,8 @@ func main() {
 		log.Printf("Writing lock-file to: %s\n", path)
 		writeErr := ioutil.WriteFile(path, []byte{}, 0660)
 		if writeErr != nil {
-			log.Panicf("Cannot write %s. Error: %s\n", path, writeErr.Error())
+			log.Panicf("Cannot write %s. To disable lock-file set env suppress_lock=true.\n Error: %s.\n", path, writeErr.Error())
 		}
 	}
-
 	log.Fatal(s.ListenAndServe())
 }

--- a/watchdog/requesthandler_test.go
+++ b/watchdog/requesthandler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandler_make(t *testing.T) {
@@ -120,38 +121,70 @@ func TestHandler_HasXDurationSecondsHeader(t *testing.T) {
 	}
 }
 
-func TestHandler_StatusOKAllowed_ForPOST(t *testing.T) {
+func TestHandler_RequestTimeoutFailsForExceededDuration(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	body := "hello"
-	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
-	if err != nil {
-		t.Fatal(err)
-	}
+	verbs := []string{"POST"}
+	for _, verb := range verbs {
 
-	config := WatchdogConfig{
-		faasProcess: "cat",
-	}
-	handler := makeRequestHandler(&config)
-	handler(rr, req)
+		body := "hello"
+		req, err := http.NewRequest(verb, "/", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	required := http.StatusOK
-	if status := rr.Code; status != required {
-		t.Errorf("handler returned wrong status code: got %v, but wanted %v",
-			status, required)
-	}
+		config := WatchdogConfig{
+			faasProcess: "sleep 2",
+			execTimeout: time.Duration(100) * time.Millisecond,
+		}
 
-	buf, _ := ioutil.ReadAll(rr.Body)
-	val := string(buf)
-	if val != body {
-		t.Errorf("Exec of cat did not return input value, %s", val)
+		handler := makeRequestHandler(&config)
+		handler(rr, req)
+
+		required := http.StatusRequestTimeout
+		if status := rr.Code; status != required {
+			t.Errorf("handler returned wrong status code for verb [%s]: got %v, but wanted %v",
+				verb, status, required)
+		}
 	}
 }
 
-func TestHandler_StatusMethodNotAllowed_ForGet(t *testing.T) {
+func TestHandler_StatusOKAllowed_ForWriteableVerbs(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/", nil)
+	verbs := []string{"POST", "PUT", "UPDATE", "DELETE"}
+	for _, verb := range verbs {
+
+		body := "hello"
+		req, err := http.NewRequest(verb, "/", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		config := WatchdogConfig{
+			faasProcess: "cat",
+		}
+		handler := makeRequestHandler(&config)
+		handler(rr, req)
+
+		required := http.StatusOK
+		if status := rr.Code; status != required {
+			t.Errorf("handler returned wrong status code for verb [%s]: got %v, but wanted %v",
+				verb, status, required)
+		}
+
+		buf, _ := ioutil.ReadAll(rr.Body)
+		val := string(buf)
+		if val != body {
+			t.Errorf("Exec of cat did not return input value, %s", val)
+		}
+	}
+}
+
+func TestHandler_StatusMethodNotAllowed_ForUnknown(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	req, err := http.NewRequest("UNKNOWN", "/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,6 +194,29 @@ func TestHandler_StatusMethodNotAllowed_ForGet(t *testing.T) {
 	handler(rr, req)
 
 	required := http.StatusMethodNotAllowed
+	if status := rr.Code; status != required {
+		t.Errorf("handler returned wrong status code: got %v, but wanted %v",
+			status, required)
+	}
+}
+
+func TestHandler_StatusOKForGETAndNoBody(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := WatchdogConfig{
+		// writeDebug:  true,
+		faasProcess: "date",
+	}
+
+	handler := makeRequestHandler(&config)
+	handler(rr, req)
+
+	required := http.StatusOK
 	if status := rr.Code; status != required {
 		t.Errorf("handler returned wrong status code: got %v, but wanted %v",
 			status, required)


### PR DESCRIPTION
Watchdog refurbishments

Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Watchdog - allow new methods with and without body.
- Enforce hard-timeout via exec_timeout variable - gives *408 Request Timeout*
- Correct bug in timeouts for read/write of HTTP. via @stealthybox #98
- Documentation for new verbs and hard timeout.
- cgi_headers now defaults to true for functions.

## How Has This Been Tested?

- Gateway unaffected by commits

- Tested through new and existing unit tests

- Tested through watchdog binary outside of container:

```
exec_timeout=2 fprocess="node test.js" ./watchdog
```

test.js:

```
function t() {
  console.log("Stop");
}
console.log("Start");

setTimeout(t, 4000);
```

Result:

```
 
$ curl localhost:8080 -v
* Rebuilt URL to: localhost:8080/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.51.0
> Accept: */*
> 
< HTTP/1.1 408 Request Timeout
< Date: Mon, 03 Jul 2017 18:25:25 GMT
< Content-Length: 16
< Content-Type: text/plain; charset=utf-8
< 
Killed process.
* Curl_http_done: called premature == 0
* Connection #0 to host localhost left intact
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have signed-off my commits with `git commit -s`
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
