### PR TITLE
Add one-liner ps1 script to start Docker stack on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,23 @@ This is my original blog post on FaaS from Janurary: [Functions as a Service blo
 
 ### TestDrive
 
-A one-line script is provided to help you get started quickly. You can test-drive FaaS on Docker Swarm with a set of sample functions as defined in the provided [docker-compose.yml](https://github.com/alexellis/faas/blob/master/docker-compose.yml) file. Alternatively if you have a Kubernetes cluster you can [start here](https://github.com/alexellis/faas-netes).
+**Docker Playground**
 
-Use your own laptop or the free community-run Docker playground: play-with-docker.com (PWD) with the button below:
+You can quickly start FaaS on Docker Swarm online using the community-run Docker playground: play-with-docker.com (PWD) by clicking the button below:
 
 [![Try in PWD](https://cdn.rawgit.com/play-with-docker/stacks/cff22438/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/alexellis/faas/master/docker-compose.yml&stack_name=func)
+
+**Docker Swarm**
+
+A set of one-line scripts are provided to help you quickly test-drive FaaS on Docker Swarm with a set of sample functions as defined in the provided [docker-compose.yml](https://github.com/alexellis/faas/blob/master/docker-compose.yml) file.
+
+- `deploy_stack.sh` - for OSX/Linux on x86_64
+- `deploy_stack.armhf.sh` - for Linux on ARM (Raspberry Pi for example)
+- `deploy_stack.ps1` - for Windows
+
+**Kubernetes**
+
+Alternatively if you have a Kubernetes cluster you can [start here](https://github.com/alexellis/faas-netes).
 
 ### [Begin the TestDrive with Docker Swarm](https://github.com/alexellis/faas/blob/master/TestDrive.md)
 

--- a/deploy_stack.armhf.sh
+++ b/deploy_stack.armhf.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+if ! [ -x "$(command -v docker)" ]; then
+  echo 'Unable to find docker command, please install Docker (https://www.docker.com/) and retry' >&2
+  exit 1
+fi
+
 echo "Deploying stack"
 docker stack deploy func --compose-file docker-compose.armhf.yml

--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -1,0 +1,11 @@
+#!ps1
+
+if (Get-Command docker -errorAction SilentlyContinue)
+{
+    Write-Host "Deploying stack"
+    docker stack deploy func --compose-file ./docker-compose.yml
+}
+else
+{
+    Write-Host "Unable to find docker command, please install Docker (https://www.docker.com/) and retry"
+}

--- a/deploy_stack.sh
+++ b/deploy_stack.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if ! [ -x "$(command -v docker)" ]; then
+  echo 'Unable to find docker command, please install Docker (https://www.docker.com/) and retry' >&2
+  exit 1
+fi
+
 echo "Deploying stack"
 docker stack deploy func --compose-file docker-compose.yml
 


### PR DESCRIPTION
Signed-off-by: John McCabe <john@johnmccabe.net>

## Description
- Adds a one-liner `deploy_stack.ps1` PowerShell script in order to start the FaaS Docker stack on Windows.
- Updates README.md to call out scripts explicitly

## Motivation and Context
When standing up the environment on Windows I defaulted to trying `docker-compose up`, only realising something was wrong when I read the warnings about `Compose does not support 'deploy' configuration`.

It also brings the user experience on Windows into line with Linux/OSX.

## How Has This Been Tested?
Have run locally on Windows 10 Pro (`10.0.15063 Build 15063`), tested the following scenarios:

- Docker not installed, returns a message pointing the user towards installing Docker.
- Swarm not initialised, the docker stack command returns a clear warning telling the user to swarm init.
- Successful deploy on a running swarm (1-node).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
