### PR TITLE
Bump armhf Gateway to 0.6.0

### DIFF
--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -7,7 +7,7 @@ services:
             - "/var/run/docker.sock:/var/run/docker.sock"
         ports:
             - 8080:8080
-        image: functions/gateway:latest-armhf
+        image: functions/gateway-armhf:0.6.0
         networks:
             - functions
         deploy:

--- a/gateway/Dockerfile.multistage.armhf
+++ b/gateway/Dockerfile.multistage.armhf
@@ -1,0 +1,29 @@
+FROM alexellis2/go-armhf:1.7.4
+
+WORKDIR /go/src/github.com/alexellis/faas/gateway
+
+COPY vendor         vendor
+
+COPY handlers       handlers
+COPY metrics        metrics
+COPY requests       requests
+COPY tests          tests
+COPY server.go      .
+COPY types          types
+COPY plugin  plugin
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gateway .
+
+FROM armhf/alpine:latest
+WORKDIR /root/
+
+EXPOSE 8080
+ENV http_proxy      ""
+ENV https_proxy     ""
+
+COPY --from=0 /go/src/github.com/alexellis/faas/gateway/gateway    .
+
+COPY assets     assets
+
+CMD ["./gateway"]
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ported multi-stage build and bumped gateway to 0.6.0 for armhf. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

armhf fell behind x86_64 in freshness

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On a single RPi 3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
