### PR TITLE
Use Roboto Mono for code blocks & use on imports for all fonts

### DIFF
--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -1,7 +1,7 @@
 <html ng-app="faasGateway">
 
-<head>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic" />
+  <head>
+    <link href="https://fonts.googleapis.com/css?family=Rationale|Roboto+Mono|Roboto:300,400,400i,500,700" rel="stylesheet">
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.css">
     <!-- Angular Material CSS now available via Google CDN; version 1.0.7 used here -->
     <link rel="stylesheet" href="style/angular-material.min.css">
@@ -104,7 +104,7 @@
                             <div layout-gt-sm="row">
                                 <md-input-container class="md-block" flex-gt-sm>
                                     <label>Request body</label>
-                                    <textarea ng-model="invocation.request" cols="80" rows="4"></textarea>
+                                    <textarea ng-model="invocation.request" class="monospace" cols="80" rows="4"></textarea>
                                 </md-input-container>
                             </div>
                             <div layout-gt-sm="row">
@@ -116,7 +116,7 @@
                             <div layout-gt-sm="row">
                                 <md-input-container class="md-block" flex-gt-sm>
                                     <label>Response body</label>
-                                    <textarea ng-model="invocationResponse" cols="80" rows=10></textarea>
+                                    <textarea ng-model="invocationResponse" class="monospace" cols="80" rows=10></textarea>
                                 </md-input-container>
                             </div>
                             <md-card-title-text>

--- a/gateway/assets/style/bootstrap.css
+++ b/gateway/assets/style/bootstrap.css
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Rationale');
-
-
 /*Taken from PWD, remove styles not used.*/
 
 .selected button {
@@ -47,4 +44,8 @@ md-input-container {
 md-input-container .md-errors-spacer {
     height: 0;
     min-height: 0;
+}
+
+.monospace {
+  font-family: 'Roboto Mono', monospace;
 }


### PR DESCRIPTION
## Description

- Use monospace font inside code blocks
- Merge all fonts imports into one import (performances improvement)

## Motivation and Context
The FaaS UI can be used to invoke functions on the cluster - it has two textboxes for request/response - both are using the default Angular material theme's font.

This requires a change in documentation, explaining that `monospace` class on an html tag will trigger code block display. 

Linked to #135 

## How Has This Been Tested?
It was not tested yet. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.