### PR TITLE
Add gateway_service_count metric for external provider

### DIFF
--- a/gateway/metrics/externalwatcher.go
+++ b/gateway/metrics/externalwatcher.go
@@ -1,0 +1,72 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package metrics
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"log"
+
+	"github.com/alexellis/faas/gateway/requests"
+)
+
+func AttachExternalWatcher(endpointURL url.URL, metricsOptions MetricOptions, label string, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	quit := make(chan struct{})
+	proxyClient := http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   3 * time.Second,
+				KeepAlive: 0,
+			}).DialContext,
+			MaxIdleConns:          1,
+			DisableKeepAlives:     true,
+			IdleConnTimeout:       120 * time.Millisecond,
+			ExpectContinueTimeout: 1500 * time.Millisecond,
+		},
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+
+				get, _ := http.NewRequest(http.MethodGet, endpointURL.String()+"system/functions", nil)
+
+				services := []requests.Function{}
+				res, err := proxyClient.Do(get)
+				if err != nil {
+					log.Println(err)
+					continue
+				}
+				bytesOut, readErr := ioutil.ReadAll(res.Body)
+				if readErr != nil {
+					log.Println(err)
+					continue
+				}
+				unmarshalErr := json.Unmarshal(bytesOut, &services)
+				if unmarshalErr != nil {
+					log.Println(err)
+					continue
+				}
+
+				for _, service := range services {
+					metricsOptions.ServiceReplicasCounter.
+						WithLabelValues(service.Name).
+						Set(float64(service.Replicas))
+				}
+
+				break
+			case <-quit:
+				return
+			}
+		}
+	}()
+}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -77,6 +77,8 @@ func main() {
 		faasHandlers.DeployFunction = makeHandler(reverseProxy, &metricsOptions)
 		faasHandlers.DeleteFunction = makeHandler(reverseProxy, &metricsOptions)
 
+		metrics.AttachExternalWatcher(*config.FunctionsProviderURL, metricsOptions, "func", time.Second*5)
+
 	} else {
 		maxRestarts := uint64(5)
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add gateway_service_count metric to Prometheus for external service provider (i.e. Kubernetes)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This will populate the gateway_service_count metric every 5 seconds for Kubernetes. It includes the replicas of a service and is normally 1 but may change with auto-scaling.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on kubeadm cluster by typing `gateway_service_count` into Prometheus and watching the value change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


![screen shot 2017-08-24 at 11 19 24 pm](https://user-images.githubusercontent.com/6358735/29691417-dfb90658-8922-11e7-9339-68a412abd1a4.png)
