### PR TITLE
should use strings.Contains() instead of stings.Index()

### DIFF
--- a/gateway/handlers/reader.go
+++ b/gateway/handlers/reader.go
@@ -47,7 +47,7 @@ func MakeFunctionReader(metricsOptions metrics.MetricOptions, c *client.Client) 
 				var envProcess string
 
 				for _, env := range service.Spec.TaskTemplate.ContainerSpec.Env {
-					if strings.Index(env, "fprocess=") > -1 {
+					if strings.Contains(env, "fprocess=") {
 						envProcess = env[len("fprocess="):]
 					}
 				}

--- a/watchdog/requesthandler_test.go
+++ b/watchdog/requesthandler_test.go
@@ -47,7 +47,7 @@ func TestHandler_HasCustomHeaderInFunction_WithCgi_Mode(t *testing.T) {
 
 	read, _ := ioutil.ReadAll(rr.Body)
 	val := string(read)
-	if strings.Index(val, "Http_Custom_Header") == -1 {
+	if !strings.Contains(val, "Http_Custom_Header") {
 		t.Errorf("'env' should printed: Http_Custom_Header, got: %s\n", val)
 
 	}
@@ -83,7 +83,7 @@ func TestHandler_DoesntHaveCustomHeaderInFunction_WithoutCgi_Mode(t *testing.T) 
 
 	read, _ := ioutil.ReadAll(rr.Body)
 	val := string(read)
-	if strings.Index(val, "Http_Custom_Header") != -1 {
+	if strings.Contains(val, "Http_Custom_Header") {
 		t.Errorf("'env' should not have printed: Http_Custom_Header, got: %s\n", val)
 
 	}


### PR DESCRIPTION
Signed-off-by: wgliang <liangcszzu@163.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
should use strings.Contains() instead of stings.Index()
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NONE
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
