### PR TITLE
Add line to mandate use of GH closure keywords - fixes #191

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,11 @@ What makes a good proposal?
 
 Please read this whole guide and make sure you agree to our DCO agreement (included below):
 
-* Sign-off your commits
+* Sign-off your commits 
 * Complete the whole template for issues and pull requests
+* [Reference addressed issues](https://help.github.com/articles/closing-issues-using-keywords/) in the PR description & commit messages - use 'Fixes #IssueNo' 
 * Always give instructions for testing
- * Give us CLI commands and output or screenshots where you can 
+* Give us CLI commands and output or screenshots where you can 
 
 **I have a question, a suggestion or need help**
 


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

Adds a line to CONTRIBUTING.md to mandate use of GH closure keywords in PRs and/or commits

## Description
Adds a line to CONTRIBUTING.md to mandate use of GH closure keywords in PRs and/or commits
Fixes #191

## Motivation and Context
Enables automatic facility inherently available within GitHub to help project maintainers manage issues.  Upon merging of the PR associated & referenced issues will also be closed.

- [X] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
