### PR TITLE
Update HACK.md

### DIFF
--- a/contrib/HACK.md
+++ b/contrib/HACK.md
@@ -9,7 +9,7 @@ $ ./build.sh
 
 Now edit the gateway service in your `docker-compose.yml` file and deploy the stack.
 
-If you want to use an overriden name then pass in the tag to the `./build.sh` script such as `./build.sh test-1`.
+If you want to use an overridden name then pass in the tag to the `./build.sh` script such as `./build.sh test-1`.
 
 ## Hack on the UI for the API Gateway
 
@@ -22,14 +22,20 @@ $ docker stack rm func
 $ docker network create func_functions --driver=overlay --attachable=true
 ```
 
-Now edit the `docker-compose.yml` file and add an attribute to the `functions` network of `attachable`.
+Now edit the `docker-compose.yml` file and replace the existing networks block with:
+
+```
+networks:
+    functions:
+        external:
+            name: func_functions
+```
 
 Now you can run the gateway as its own container and bind-mount in the HTML assets.
 
 ```
-$ cd faas
 $ docker run -v `pwd`/gateway/assets:/root/assets -v "/var/run/docker.sock:/var/run/docker.sock" \
--p 8080:8080 --network=func_functions -ti functions/gateway:latest-dev
+-p 8080:8080 --network=func_functions -itd functions/gateway:latest-dev
 ```
 
-Now deploy the rest of the stack with:  `./deploy_stack.sh`.
+Now deploy the rest of the stack with: `./deploy_stack.sh`.

--- a/contrib/HACK.md
+++ b/contrib/HACK.md
@@ -35,7 +35,7 @@ Now you can run the gateway as its own container and bind-mount in the HTML asse
 
 ```
 $ docker run -v `pwd`/gateway/assets:/root/assets -v "/var/run/docker.sock:/var/run/docker.sock" \
--p 8080:8080 --network=func_functions -itd functions/gateway:latest-dev
+-p 8080:8080 --network=func_functions -d functions/gateway:latest-dev
 ```
 
 Now deploy the rest of the stack with: `./deploy_stack.sh`.


### PR DESCRIPTION
When creating the stack using an external network, this must be stated in the `docker-compose.yml` file otherwise the following error is reported:

```
alexs-macbook-pro:faas alex$ ./deploy_stack.sh
Deploying stack
Creating network func_functions
Error response from daemon: network with name func_functions already exists
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
