### PR TITLE
Add tests around error handing done in #196

### DIFF
--- a/gateway/handlers/createhandler.go
+++ b/gateway/handlers/createhandler.go
@@ -30,6 +30,7 @@ func MakeNewFunctionHandler(metricsOptions metrics.MetricOptions, c *client.Clie
 		request := requests.CreateFunctionRequest{}
 		err := json.Unmarshal(body, &request)
 		if err != nil {
+			log.Println("Error parsing request:", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -43,7 +44,7 @@ func MakeNewFunctionHandler(metricsOptions metrics.MetricOptions, c *client.Clie
 		if len(request.RegistryAuth) > 0 {
 			auth, err := BuildEncodedAuthConfig(request.RegistryAuth, request.Image)
 			if err != nil {
-				log.Println("Error while building registry auth configuration", err)
+				log.Println("Error building registry auth configuration:", err)
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte("Invalid registry auth"))
 				return
@@ -54,7 +55,7 @@ func MakeNewFunctionHandler(metricsOptions metrics.MetricOptions, c *client.Clie
 
 		response, err := c.ServiceCreate(context.Background(), spec, options)
 		if err != nil {
-			log.Println(err)
+			log.Println("Error creating service:", err)
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("Deployment error: " + err.Error()))
 			return

--- a/gateway/tests/integration/createfunction_test.go
+++ b/gateway/tests/integration/createfunction_test.go
@@ -8,35 +8,26 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/alexellis/faas/gateway/requests"
 )
 
-type PostFunctionRequest struct {
-	Image      string `json:"image"`
-	EnvProcess string `json:"envProcess"`
-	Network    string `json:"network"`
-	Service    string `json:"service"`
-}
-
-type DeleteFunctionRequest struct {
-	FunctionName string `json:"functionName"`
-}
-
-func createFunction(request PostFunctionRequest) (string, int, error) {
+func createFunction(request requests.CreateFunctionRequest) (string, int, error) {
 	marshalled, _ := json.Marshal(request)
 	return fireRequest("http://localhost:8080/system/functions", http.MethodPost, string(marshalled))
 }
 
 func deleteFunction(name string) (string, int, error) {
-	marshalled, _ := json.Marshal(DeleteFunctionRequest{name})
+	marshalled, _ := json.Marshal(requests.DeleteFunctionRequest{name})
 	return fireRequest("http://localhost:8080/system/functions", http.MethodDelete, string(marshalled))
 }
 
 func TestCreate_ValidRequest(t *testing.T) {
-	request := PostFunctionRequest{
-		"functions/resizer",
-		"",
-		"func_functions",
-		"test_resizer",
+	request := requests.CreateFunctionRequest{
+		Service:    "test_resizer",
+		Image:      "functions/resizer",
+		Network:    "func_functions",
+		EnvProcess: "",
 	}
 
 	_, code, err := createFunction(request)
@@ -56,11 +47,11 @@ func TestCreate_ValidRequest(t *testing.T) {
 }
 
 func TestCreate_InvalidImage(t *testing.T) {
-	request := PostFunctionRequest{
-		"a b c",
-		"",
-		"func_functions",
-		"test_resizer",
+	request := requests.CreateFunctionRequest{
+		Service:    "test_resizer",
+		Image:      "a b c",
+		Network:    "func_functions",
+		EnvProcess: "",
 	}
 
 	body, code, err := createFunction(request)
@@ -84,11 +75,11 @@ func TestCreate_InvalidImage(t *testing.T) {
 }
 
 func TestCreate_InvalidNetwork(t *testing.T) {
-	request := PostFunctionRequest{
-		"functions/resizer",
-		"",
-		"non_existent_network",
-		"test_resizer",
+	request := requests.CreateFunctionRequest{
+		Service:    "test_resizer",
+		Image:      "functions/resizer",
+		Network:    "non_existent_network",
+		EnvProcess: "",
 	}
 
 	body, code, err := createFunction(request)

--- a/gateway/tests/integration/createfunction_test.go
+++ b/gateway/tests/integration/createfunction_test.go
@@ -46,8 +46,9 @@ func TestCreate_ValidRequest(t *testing.T) {
 		t.Fail()
 	}
 
-	if code != http.StatusOK {
-		t.Errorf("Got HTTP code: %d, want %d\n", code, http.StatusOK)
+	expectedErrorCode := http.StatusOK
+	if code != expectedErrorCode {
+		t.Errorf("Got HTTP code: %d, want %d\n", code, expectedErrorCode)
 		return
 	}
 

--- a/gateway/tests/integration/createfunction_test.go
+++ b/gateway/tests/integration/createfunction_test.go
@@ -4,13 +4,42 @@
 package inttests
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
-func TestCreate_ValidJson(t *testing.T) {
-	reqBody := `{}`
-	_, code, err := fireRequest("http://localhost:8080/system/functions", http.MethodPost, reqBody)
+type PostFunctionRequest struct {
+	Image      string `json:"image"`
+	EnvProcess string `json:"envProcess"`
+	Network    string `json:"network"`
+	Service    string `json:"service"`
+}
+
+type DeleteFunctionRequest struct {
+	FunctionName string `json:"functionName"`
+}
+
+func createFunction(request PostFunctionRequest) (string, int, error) {
+	marshalled, _ := json.Marshal(request)
+	return fireRequest("http://localhost:8080/system/functions", http.MethodPost, string(marshalled))
+}
+
+func deleteFunction(name string) (string, int, error) {
+	marshalled, _ := json.Marshal(DeleteFunctionRequest{name})
+	return fireRequest("http://localhost:8080/system/functions", http.MethodDelete, string(marshalled))
+}
+
+func TestCreate_ValidRequest(t *testing.T) {
+	request := PostFunctionRequest{
+		"functions/resizer",
+		"",
+		"func_functions",
+		"test_resizer",
+	}
+
+	_, code, err := createFunction(request)
 
 	if err != nil {
 		t.Log(err)
@@ -18,11 +47,70 @@ func TestCreate_ValidJson(t *testing.T) {
 	}
 
 	if code != http.StatusOK {
-		t.Errorf("Got HTTP code: %d, want %d\n", code, http.StatusBadRequest)
+		t.Errorf("Got HTTP code: %d, want %d\n", code, http.StatusOK)
+		return
+	}
+
+	deleteFunction("test_resizer")
+}
+
+func TestCreate_InvalidImage(t *testing.T) {
+	request := PostFunctionRequest{
+		"a b c",
+		"",
+		"func_functions",
+		"test_resizer",
+	}
+
+	body, code, err := createFunction(request)
+
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	expectedErrorCode := http.StatusBadRequest
+	if code != expectedErrorCode {
+		t.Errorf("Got HTTP code: %d, want %d\n", code, expectedErrorCode)
+		return
+	}
+
+	expectedErrorSlice := "is not a valid repository/tag"
+	if !strings.Contains(body, expectedErrorSlice) {
+		t.Errorf("Error message %s does not contain: %s\n", body, expectedErrorSlice)
+		return
 	}
 }
 
-func TestCreateBadFunctionNotJson(t *testing.T) {
+func TestCreate_InvalidNetwork(t *testing.T) {
+	request := PostFunctionRequest{
+		"functions/resizer",
+		"",
+		"non_existent_network",
+		"test_resizer",
+	}
+
+	body, code, err := createFunction(request)
+
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	expectedErrorCode := http.StatusBadRequest
+	if code != expectedErrorCode {
+		t.Errorf("Got HTTP code: %d, want %d\n", code, expectedErrorCode)
+		return
+	}
+
+	expectedErrorSlice := "network non_existent_network not found"
+	if !strings.Contains(body, expectedErrorSlice) {
+		t.Errorf("Error message %s does not contain: %s\n", body, expectedErrorSlice)
+		return
+	}
+}
+
+func TestCreate_InvalidJson(t *testing.T) {
 	reqBody := `not json`
 	_, code, err := fireRequest("http://localhost:8080/system/functions", http.MethodPost, reqBody)
 


### PR DESCRIPTION
Signed-off-by: Alex Young <alex@heuris.io>

## Description

With an OpenFaas swarm stack running, run the gateway integration tests by doing the following from the root directory:
```
cd gateway/tests
go test ./integration
```
You should see all integration tests pass. Two were currently failing one due to the change done in #196 and another to do with an `X-Function` related issue that has been fixed in d2b15241c66a797cfacf903da6f24e5991893ff9.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
