### PR TITLE
Added link to DownNotifier post

### DIFF
--- a/community.md
+++ b/community.md
@@ -35,6 +35,7 @@ There are three main Github repos
 
 | Blog/repo name and description                                          | Author       | Site     | Date        |
 |---------------------------------------------------------------------|--------------|----------|-------------|
+| [Create your own DownNotifier with OpenFaaS](http://jmkhael.io/downnotifier-site-pinger/)| Johnny Mkhael | jmkhael.io | 22-Sep-2017|
 | [OpenFaaS on Azure (Swarm)](https://blogs.technet.microsoft.com/livedevopsinjapan/2017/09/21/openfaas-on-azure-swarm/) | Tsuyoshi Ushio | technet.microsoft.com | 21-Sep-2017 |
 | [OpenFaaS on ACS (Kubernetes)](https://blogs.technet.microsoft.com/livedevopsinjapan/2017/09/19/open-faas-on-acs-kubernetes/) | Tsuyoshi Ushio | technet.microsoft.com | 19-Sep-2017 |
 | [Integrating OpenFaaS and GraphQL](https://medium.com/@kenfdev/integrating-openfaas-and-graphql-experimental-1870bd22f2a) | Ken Fukuyama | medium.com/@kenfdev | 10-Sep-2017 |


### PR DESCRIPTION
Signed-off-by: Johnny Mkhael <johnny.mkhael@gmail.com>

Adding a link to the community page concerning the last blog post I did.

Basically I created an OpenFaaS based stack to keep pinging my blog and then send a Slack notification in case the blog is down,

How Has This Been Tested?

NA

Checklist:

[x] I've read the CONTRIBUTION guide
[x] I have signed-off my commits with git commit -s